### PR TITLE
feat: per-app release flow via tag promote and pin PR

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -1,13 +1,20 @@
 name: App release
 
-# Cut a per-app release by pushing a tag <image>-vX.Y.Z (e.g. warden-v1.4.0).
-# Promotes the already-built (tested) :<sha> image to :X.Y.Z without rebuilding,
-# then opens a PR pinning the compose image off :latest to the released version.
+# Tier-1, per-app release (distinct from release.yml, which is Tier-2 — the weekly
+# python-semantic-release that versions the whole repo). Cut one by pushing a tag
+# <image>-vX.Y.Z (e.g. warden-v1.4.0): this promotes the already-built (tested)
+# :<sha> image to :X.Y.Z without rebuilding, then opens a PR pinning the compose
+# image off :latest to the released version.
 
 on:
     push:
         tags:
             - "*-v*"
+
+# Serialize releases of the same tag; never cancel an in-flight promote midway.
+concurrency:
+    group: app-release-${{ github.ref }}
+    cancel-in-progress: false
 
 permissions:
     contents: write
@@ -24,8 +31,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
 
             - name: Set up uv
               uses: astral-sh/setup-uv@v5

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -1,0 +1,85 @@
+name: App release
+
+# Cut a per-app release by pushing a tag <image>-vX.Y.Z (e.g. warden-v1.4.0).
+# Promotes the already-built (tested) :<sha> image to :X.Y.Z without rebuilding,
+# then opens a PR pinning the compose image off :latest to the released version.
+
+on:
+    push:
+        tags:
+            - "*-v*"
+
+permissions:
+    contents: write
+    packages: write
+    pull-requests: write
+
+env:
+    REGISTRY: ghcr.io
+    REGISTRY_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+    promote:
+        name: Promote and pin
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v5
+              with:
+                  enable-cache: true
+
+            - name: Resolve release tag
+              id: rel
+              run: |
+                  set -euo pipefail
+                  info="$(uv run ci release "${GITHUB_REF_NAME}" .)"
+                  echo "image=$(echo "$info" | jq -r .image_name)" >> "$GITHUB_OUTPUT"
+                  echo "version=$(echo "$info" | jq -r .version)" >> "$GITHUB_OUTPUT"
+                  echo "compose=$(echo "$info" | jq -r .compose_file)" >> "$GITHUB_OUTPUT"
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to ghcr.io
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Promote :sha -> :version
+              # The tagged commit's image was built+pushed as :<sha> on main; retag it
+              # to the released version server-side (no rebuild — released == tested).
+              run: |
+                  set -euo pipefail
+                  repo="${REGISTRY}/${REGISTRY_NAMESPACE}/${{ steps.rel.outputs.image }}"
+                  docker buildx imagetools create "${repo}:${GITHUB_SHA}" \
+                      --tag "${repo}:${{ steps.rel.outputs.version }}"
+
+            - name: Open PR pinning the compose image
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  image="${{ steps.rel.outputs.image }}"
+                  version="${{ steps.rel.outputs.version }}"
+                  compose="${{ steps.rel.outputs.compose }}"
+                  # Pin this image's tag (whatever it currently is) to the released version.
+                  sed -i -E "s#/${image}:[^\"[:space:]]+#/${image}:${version}#" "$compose"
+                  if git diff --quiet -- "$compose"; then
+                      echo "Pin already at ${version}; nothing to PR."; exit 0
+                  fi
+                  branch="release/${image}-${version}"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git checkout -b "$branch"
+                  git add "$compose"
+                  git commit -m "chore: pin ${image} to ${version}"
+                  git push -f origin "$branch"
+                  gh pr create --base main --head "$branch" \
+                      --title "chore: pin ${image} to ${version}" \
+                      --body "Promoted \`${image}:${version}\` from the tested \`:${GITHUB_SHA}\` image. Pins ${compose} off \`:latest\`."

--- a/tools/ci/ci/affected.py
+++ b/tools/ci/ci/affected.py
@@ -53,6 +53,17 @@ class Unit:
         """Bare image name (last path segment), e.g. ``warden`` or ``homelab-devbox``."""
         return self.image_key.rsplit("/", 1)[-1]
 
+    def as_dict(self) -> dict:
+        """JSON-serializable view shared by the build matrix and release resolution."""
+        return {
+            "service": self.service,
+            "image_name": self.image_name,
+            "context": self.context,
+            "dockerfile": self.dockerfile,
+            "compose_file": self.compose_file,
+            "stack_dir": self.stack_dir,
+        }
+
 
 def _image_key(image: str) -> str:
     image = image.split("@", 1)[0]  # drop @sha256:... digest
@@ -140,14 +151,4 @@ def compute_matrix(repo_root: str | os.PathLike[str], changed_files: list[str]) 
     """The deduped build matrix (one entry per image) for a set of changed files."""
     units = discover_units(repo_root)
     selected = units if tooling_changed(changed_files) else affected_units(changed_files, units)
-    return [
-        {
-            "service": u.service,
-            "image_name": u.image_name,
-            "context": u.context,
-            "dockerfile": u.dockerfile,
-            "compose_file": u.compose_file,
-            "stack_dir": u.stack_dir,
-        }
-        for u in dedupe_by_image(selected)
-    ]
+    return [u.as_dict() for u in dedupe_by_image(selected)]

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -4,6 +4,7 @@ Subcommands:
   ci affected [REPO_ROOT] [FILE ...]   print the affected build matrix as JSON
                                        (files default to stdin, newline-separated)
   ci test [SELECTOR] [--tier T] [--affected]   run app pytest suites by tier
+  ci release TAG [REPO_ROOT]            resolve a release tag to {image,version,compose} JSON
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ import json
 import subprocess
 import sys
 
-from ci import affected, apptests
+from ci import affected, apptests, release
 
 
 def _cmd_affected(args: argparse.Namespace) -> int:
@@ -37,6 +38,15 @@ def _cmd_test(args: argparse.Namespace) -> int:
     return apptests.run_tests(args.repo_root, selected, apptests.tiers_to_run(args.tier))
 
 
+def _cmd_release(args: argparse.Namespace) -> int:
+    info = release.release_info(args.repo_root, args.tag)
+    if info is None:
+        print(f"not a release tag for a known image: {args.tag}", file=sys.stderr)
+        return 1
+    print(json.dumps(info))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ci")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -53,6 +63,11 @@ def build_parser() -> argparse.ArgumentParser:
     test.add_argument("--base", default="origin/main")
     test.add_argument("--repo-root", default=".")
     test.set_defaults(func=_cmd_test)
+
+    rel = sub.add_parser("release", help="resolve a release tag to image/version/compose JSON")
+    rel.add_argument("tag")
+    rel.add_argument("repo_root", nargs="?", default=".")
+    rel.set_defaults(func=_cmd_release)
     return parser
 
 

--- a/tools/ci/ci/release.py
+++ b/tools/ci/ci/release.py
@@ -1,0 +1,52 @@
+"""Per-app (per-image) release helpers — the `ci release` logic.
+
+A release is cut by pushing a git tag ``<image_name>-vX.Y.Z`` (e.g.
+``warden-v1.2.0``, ``takeout-worker-v0.3.1``). The release workflow promotes the
+already-built ``:<sha>`` image to ``:X.Y.Z`` (no rebuild) and bumps the compose pin.
+
+Parsing is the fiddly part — image names themselves contain hyphens and digits
+(``takeout-manager``, ``iperf3-server``), so the version is split on the last
+``-v`` that is followed by a digit.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from ci.affected import Unit, discover_units
+
+# <image>-v<version>, where <version> starts with a digit. `.+` is greedy so the
+# split lands on the last `-v<digit>`, keeping hyphenated image names intact.
+_TAG_RE = re.compile(r"^(?P<image>.+)-v(?P<version>\d[^\s]*)$")
+
+
+def parse_release_tag(tag: str) -> tuple[str, str] | None:
+    """``warden-v1.2.0`` -> ``("warden", "1.2.0")``; ``None`` if not a release tag."""
+    match = _TAG_RE.match(tag or "")
+    if not match:
+        return None
+    return match.group("image"), match.group("version")
+
+
+def resolve_unit(image_name: str, units: list[Unit]) -> Unit | None:
+    """The buildable unit that produces ``image_name`` (or ``None``)."""
+    return next((u for u in units if u.image_name == image_name), None)
+
+
+def release_info(repo_root: str | os.PathLike[str], tag: str) -> dict | None:
+    """Resolve a release tag to its image/version/unit, or ``None`` if not a
+    valid release tag for a known buildable image."""
+    parsed = parse_release_tag(tag)
+    if not parsed:
+        return None
+    image_name, version = parsed
+    unit = resolve_unit(image_name, discover_units(repo_root))
+    if not unit:
+        return None
+    return {
+        "image_name": image_name,
+        "version": version,
+        "service": unit.service,
+        "compose_file": unit.compose_file,
+    }

--- a/tools/ci/ci/release.py
+++ b/tools/ci/ci/release.py
@@ -16,9 +16,9 @@ import re
 
 from ci.affected import Unit, discover_units
 
-# <image>-v<version>, where <version> starts with a digit. `.+` is greedy so the
-# split lands on the last `-v<digit>`, keeping hyphenated image names intact.
-_TAG_RE = re.compile(r"^(?P<image>.+)-v(?P<version>\d[^\s]*)$")
+# <image>-vX.Y.Z (with optional pre-release/build suffix). `.+` is greedy so the
+# split lands on the last `-vX.Y.Z`, keeping hyphenated image names intact.
+_TAG_RE = re.compile(r"^(?P<image>.+)-v(?P<version>\d+\.\d+\.\d+(?:[-+.]\S+)?)$")
 
 
 def parse_release_tag(tag: str) -> tuple[str, str] | None:
@@ -44,9 +44,4 @@ def release_info(repo_root: str | os.PathLike[str], tag: str) -> dict | None:
     unit = resolve_unit(image_name, discover_units(repo_root))
     if not unit:
         return None
-    return {
-        "image_name": image_name,
-        "version": version,
-        "service": unit.service,
-        "compose_file": unit.compose_file,
-    }
+    return {"version": version, **unit.as_dict()}

--- a/tools/ci/tests/test_release.py
+++ b/tools/ci/tests/test_release.py
@@ -33,6 +33,8 @@ def test_parse_valid_release_tags(tag, expected):
         "warden-1.2.0",  # missing the v
         "random-tag",
         "warden-vX.Y.Z",  # version must start with a digit
+        "warden-v1",  # not full X.Y.Z
+        "warden-v1.2",  # not full X.Y.Z
         "",
     ],
 )

--- a/tools/ci/tests/test_release.py
+++ b/tools/ci/tests/test_release.py
@@ -1,0 +1,95 @@
+"""Tests for release-tag parsing and resolution (the `ci release` logic)."""
+
+from __future__ import annotations
+
+import pytest
+
+import textwrap
+from pathlib import Path
+
+from ci.affected import Unit
+from ci.release import parse_release_tag, release_info, resolve_unit
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("warden-v1.2.0", ("warden", "1.2.0")),
+        ("takeout-manager-v0.3.1", ("takeout-manager", "0.3.1")),  # hyphenated image
+        ("takeout-worker-v2.0.0", ("takeout-worker", "2.0.0")),
+        ("iperf3-server-v1.0.0", ("iperf3-server", "1.0.0")),  # digit in image name
+        ("homelab-devbox-v3.4.5", ("homelab-devbox", "3.4.5")),
+        ("warden-v1.2.0-rc1", ("warden", "1.2.0-rc1")),  # pre-release suffix
+    ],
+)
+def test_parse_valid_release_tags(tag, expected):
+    assert parse_release_tag(tag) == expected
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "v1.2.0",  # no image
+        "warden-1.2.0",  # missing the v
+        "random-tag",
+        "warden-vX.Y.Z",  # version must start with a digit
+        "",
+    ],
+)
+def test_parse_rejects_non_release_tags(tag):
+    assert parse_release_tag(tag) is None
+
+
+def _unit(image_name):
+    return Unit(
+        service=image_name,
+        image=f"ghcr.io/ns/{image_name}:latest",
+        stack_dir=f"stacks/apps/{image_name}",
+        context=f"stacks/apps/{image_name}",
+        dockerfile=None,
+        compose_file=f"stacks/apps/{image_name}/docker-compose.yml",
+        watch=(),
+    )
+
+
+def test_resolve_unit_matches_by_image_name():
+    units = [_unit("warden"), _unit("homelab-devbox")]
+    assert resolve_unit("homelab-devbox", units).service == "homelab-devbox"
+
+
+def test_resolve_unit_returns_none_when_no_match():
+    assert resolve_unit("nope", [_unit("warden")]) is None
+
+
+def _write_repo(tmp_path):
+    (tmp_path / "stacks/apps/warden").mkdir(parents=True)
+    (tmp_path / "stacks/apps/warden/docker-compose.yml").write_text(
+        textwrap.dedent(
+            """
+            services:
+              warden:
+                image: ${REGISTRY:-ghcr.io}/${REGISTRY_NAMESPACE:-ns}/warden:latest
+                build: { context: ., dockerfile: app/Dockerfile }
+            """
+        )
+    )
+    return tmp_path
+
+
+def test_release_info_resolves_tag_to_unit(tmp_path):
+    _write_repo(tmp_path)
+    info = release_info(tmp_path, "warden-v1.4.0")
+    assert info["image_name"] == "warden"
+    assert info["version"] == "1.4.0"
+    assert info["compose_file"] == "stacks/apps/warden/docker-compose.yml"
+    assert info["service"] == "warden"
+
+
+def test_release_info_none_for_unknown_image(tmp_path):
+    _write_repo(tmp_path)
+    assert release_info(tmp_path, "ghost-v1.0.0") is None
+
+
+def test_release_info_none_for_non_release_tag(tmp_path):
+    _write_repo(tmp_path)
+    assert release_info(tmp_path, "not-a-release") is None


### PR DESCRIPTION
## What

Per-app (per-image) release flow — the deferred "Tier-1 release" piece. Cut a release by pushing a tag `<image>-vX.Y.Z` (e.g. `warden-v1.4.0`); CI promotes the already-tested image and pins the deploy off `:latest`.

## How

- **`ci release <tag>`** (new subcommand in `tools/ci`) parses `<image>-vX.Y.Z` — handling hyphenated/digit image names (`takeout-manager`, `iperf3-server`, `homelab-devbox`) — and resolves it to the buildable unit (compose file + image). Pure, unit-tested (16 tests, TDD red→green).
- **`app-release.yml`** on `*-v*` tags:
  1. Resolve the tag via `ci release`.
  2. **Promote** `:<sha>` → `:X.Y.Z` with `imagetools` (no rebuild — released == tested).
  3. Open a **PR pinning** the compose image off `:latest` to `:X.Y.Z` (targeted sed; in a multi-image stack only the released image's line changes — verified).

## Usage

```
git tag warden-v1.4.0 <commit-built-on-main>
git push origin warden-v1.4.0
```
→ `warden:1.4.0` appears in ghcr (promoted from the tested `:sha`), and a PR pins `stacks/apps/warden/docker-compose.yml` to it.

## Notes / scope

- Promotes from `:<sha>`, so tag a commit already built on `main` (its `:sha` exists). Tagging an unbuilt commit fails the promote — intentional (released must equal tested).
- Tier-2 (the weekly `python-semantic-release` repo version) is unchanged; this is the independent per-app tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
