### PR TITLE
refactor: app-release promote-only (drop auto pin PR)

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -2,9 +2,9 @@ name: App release
 
 # Tier-1, per-app release (distinct from release.yml, which is Tier-2 — the weekly
 # python-semantic-release that versions the whole repo). Cut one by pushing a tag
-# <image>-vX.Y.Z (e.g. warden-v1.4.0): this promotes the already-built (tested)
-# :<sha> image to :X.Y.Z without rebuilding, then opens a PR pinning the compose
-# image off :latest to the released version.
+# <image>-vX.Y.Z (e.g. warden-v1.4.0): this PROMOTES the already-built (tested)
+# :<sha> image to :X.Y.Z without rebuilding. It does NOT touch deploy pins —
+# bump the compose image tag to the released version yourself when ready to deploy.
 
 on:
     push:
@@ -17,9 +17,8 @@ concurrency:
     cancel-in-progress: false
 
 permissions:
-    contents: write
+    contents: read
     packages: write
-    pull-requests: write
 
 env:
     REGISTRY: ghcr.io
@@ -27,7 +26,7 @@ env:
 
 jobs:
     promote:
-        name: Promote and pin
+        name: Promote
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -44,7 +43,6 @@ jobs:
                   info="$(uv run ci release "${GITHUB_REF_NAME}" .)"
                   echo "image=$(echo "$info" | jq -r .image_name)" >> "$GITHUB_OUTPUT"
                   echo "version=$(echo "$info" | jq -r .version)" >> "$GITHUB_OUTPUT"
-                  echo "compose=$(echo "$info" | jq -r .compose_file)" >> "$GITHUB_OUTPUT"
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -64,27 +62,4 @@ jobs:
                   repo="${REGISTRY}/${REGISTRY_NAMESPACE}/${{ steps.rel.outputs.image }}"
                   docker buildx imagetools create "${repo}:${GITHUB_SHA}" \
                       --tag "${repo}:${{ steps.rel.outputs.version }}"
-
-            - name: Open PR pinning the compose image
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  set -euo pipefail
-                  image="${{ steps.rel.outputs.image }}"
-                  version="${{ steps.rel.outputs.version }}"
-                  compose="${{ steps.rel.outputs.compose }}"
-                  # Pin this image's tag (whatever it currently is) to the released version.
-                  sed -i -E "s#/${image}:[^\"[:space:]]+#/${image}:${version}#" "$compose"
-                  if git diff --quiet -- "$compose"; then
-                      echo "Pin already at ${version}; nothing to PR."; exit 0
-                  fi
-                  branch="release/${image}-${version}"
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git checkout -b "$branch"
-                  git add "$compose"
-                  git commit -m "chore: pin ${image} to ${version}"
-                  git push -f origin "$branch"
-                  gh pr create --base main --head "$branch" \
-                      --title "chore: pin ${image} to ${version}" \
-                      --body "Promoted \`${image}:${version}\` from the tested \`:${GITHUB_SHA}\` image. Pins ${compose} off \`:latest\`."
+                  echo "Promoted \`${repo}:${{ steps.rel.outputs.version }}\` from \`:${GITHUB_SHA}\`." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Simplifies the release flow per the limitations the first real tag surfaced: Actions can't create PRs by default, and even enabled, GITHUB_TOKEN PRs don't trigger the required `Build gate`.

So `app-release.yml` now **promotes only** — tag `<image>-vX.Y.Z` retags the tested `:<sha>` to `:X.Y.Z` (proven working: `warden:0.1.0` is in ghcr). Updating the deploy pin (`:latest` → `:X.Y.Z` in compose) is a deliberate manual bump/commit when you're ready to deploy — cleanly separating *minting a release* from *deploying it*. Also drops the now-unneeded `contents: write` / `pull-requests: write` permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)