### PR TITLE
test: takeout-manager coverage gate to 90

### DIFF
--- a/stacks/apps/takeout-manager/manager/pyproject.toml
+++ b/stacks/apps/takeout-manager/manager/pyproject.toml
@@ -32,4 +32,4 @@ markers = [
     "integration: needs external services (real process / fakes / docker)",
     "e2e: full black-box end-to-end (docker compose)",
 ]
-addopts = "--strict-markers --cov=backend --cov-report=term-missing --cov-fail-under=88"
+addopts = "--strict-markers --cov=backend --cov-report=term-missing --cov-fail-under=90"


### PR DESCRIPTION
Combined coverage already sits at 95%; raise the gate 88 → 90 to match the uniform target across apps. No new tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)