### PR TITLE
chore: bump kenku to 0.33.1 and sync uv.lock version

### DIFF
--- a/stacks/apps/downloads/docker-compose.yml
+++ b/stacks/apps/downloads/docker-compose.yml
@@ -261,7 +261,7 @@ services:
                     - node.labels.downloads == true
 
     kenku:
-        image: ghcr.io/chutch3/kenku:0.28.1
+        image: ghcr.io/chutch3/kenku:0.33.1
         container_name: kenku
         # settings.json + imageCache live under /usr/share/kenku-api and are written by the
         # app at runtime, so this is a plain writable volume (kenku_config). Configure

--- a/uv.lock
+++ b/uv.lock
@@ -790,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "homelab"
-version = "3.18.0"
+version = "3.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cairosvg" },


### PR DESCRIPTION
Two trivial maintenance changes that were sitting uncommitted in the working tree:

- **kenku `0.28.1` → `0.33.1`** (`stacks/apps/downloads/docker-compose.yml`) — forward image bump, consistent with the stack's existing kenku bump history.
- **`uv.lock` `homelab` 3.18.0 → 3.20.0** — lockfile catching up to the already-released `pyproject.toml` version (semantic-release bumped pyproject; the lock's recorded version lagged).

Each is a separate commit. No functional/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)