### PR TITLE
feat: add disk-space guard to warden

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,6 +227,10 @@ WARDEN_RESERVE_PCT=20
 WARDEN_FALLBACK_SEARCHES_PER_DAY=200
 WARDEN_RESET_AT_LOCAL=00:00
 WARDEN_POLL_INTERVAL_SEC=300
+# Space guard: pause hunting when projected free disk (smallest *arr root-folder free
+# space minus the bytes still downloading in the queue) drops below this many GB.
+# Leave unset/empty to disable the guard (there is no default floor).
+WARDEN_MIN_FREE_GB=
 # Optional Prowlarr integration: derive each source's daily budget from real
 # per-indexer query limits. Omit to pace against WARDEN_FALLBACK_SEARCHES_PER_DAY.
 WARDEN_PROWLARR_URL=http://prowlarr:9696

--- a/stacks/apps/warden/README.md
+++ b/stacks/apps/warden/README.md
@@ -50,6 +50,20 @@ If Prowlarr is unreachable it falls back to a flat per-day budget.
   (`downloadClientUnavailable` over half the queue), so warden never deletes data
   during an outage.
 
+## Space guard
+
+Warden can pause hunting when the disk is running low, so it stops asking for new
+releases before the drive fills. Each tick it reads the smallest free space across a
+source's *arr root folders and subtracts the bytes still downloading in that source's
+queue (in-flight grabs that haven't landed yet); if that **projected headroom** falls
+below `WARDEN_MIN_FREE_GB`, hunting is skipped for the tick. The janitor still runs, so a
+full disk keeps getting cleaned while hunting is paused.
+
+The guard is **off unless `WARDEN_MIN_FREE_GB` is set** — there is no default floor. If a
+root folder's free space can't be read (endpoint error, or all folders inaccessible),
+warden hunts anyway rather than freeze. `warden_space_blocked`, `warden_free_bytes`, and
+`warden_projected_free_bytes` expose the state per source.
+
 ## Search efficacy & backoff
 
 Warden correlates each search it fires against Radarr/Sonarr grab history: a grab for
@@ -79,6 +93,7 @@ All via `WARDEN_*` env vars. Instances are discovered from `WARDEN_RADARR_URL` /
 | `WARDEN_POLL_INTERVAL_SEC` | `300` | seconds between ticks |
 | `WARDEN_RESERVE_PCT` | `20` | quota held back from the indexer limit |
 | `WARDEN_RESET_AT_LOCAL` | `00:00` | when the daily budget resets |
+| `WARDEN_MIN_FREE_GB` | _(unset)_ | pause hunting when projected free disk drops below this (GB); unset disables the space guard |
 | `WARDEN_STALE_GRACE_HOURS` | `48` | age before a stalled item is removable |
 | `WARDEN_STALE_NO_PROGRESS_HOURS` | `12` | how long an item must stay completely frozen before removal |
 | `WARDEN_STALE_JITTER_TOLERANCE_MB` | `0` | drain below this counts as frozen (`0` = any progress resets the clock) |

--- a/stacks/apps/warden/app/tests/factories.py
+++ b/stacks/apps/warden/app/tests/factories.py
@@ -75,7 +75,8 @@ class FakeArrClient:
 
     def __init__(self, name: str, missing: list[WantedItem], cutoff: list[WantedItem] | None = None,
                  raises: bool = False, arr_type: ArrType = ArrType.RADARR, queue=None,
-                 remove_raises: bool = False, grabs=None, grab_raises: bool = False) -> None:
+                 remove_raises: bool = False, grabs=None, grab_raises: bool = False,
+                 root_folders=None, root_folders_raises: bool = False) -> None:
         self.name = name
         self.arr_type = arr_type
         self._missing = missing
@@ -85,9 +86,12 @@ class FakeArrClient:
         self._remove_raises = remove_raises
         self._grabs = grabs or []
         self._grab_raises = grab_raises
+        self._root_folders = root_folders or []
+        self._root_folders_raises = root_folders_raises
         self.searched: list[list[int]] = []
         self.removed: list[int] = []
         self.grabbed_since: list = []
+        self.root_folder_calls: int = 0
 
     async def list_missing(self) -> list[WantedItem]:
         if self._raises:
@@ -116,3 +120,9 @@ class FakeArrClient:
         if self._grab_raises:
             raise RuntimeError("history failed")
         return list(self._grabs)
+
+    async def list_root_folders(self):
+        self.root_folder_calls += 1
+        if self._root_folders_raises:
+            raise RuntimeError("rootfolder failed")
+        return list(self._root_folders)

--- a/stacks/apps/warden/app/tests/integration/conftest.py
+++ b/stacks/apps/warden/app/tests/integration/conftest.py
@@ -158,14 +158,16 @@ def commands(server: HTTPServer) -> list[dict]:
     return [r.get_json() for r in _records(server, "/api/v3/command", "POST")]
 
 
-def prime_radarr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=()) -> None:
+def prime_radarr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=(),
+                 free_space=None) -> None:
     _prime_arr(server, missing=missing, cutoff=cutoff, queue=queue, grab_ids=grab_ids,
-               id_field="movieId")
+               id_field="movieId", free_space=free_space)
 
 
-def prime_sonarr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=()) -> None:
+def prime_sonarr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=(),
+                 free_space=None) -> None:
     _prime_arr(server, missing=missing, cutoff=cutoff, queue=queue, grab_ids=grab_ids,
-               id_field="episodeId")
+               id_field="episodeId", free_space=free_space)
 
 
 def _missing_record(m) -> dict:
@@ -192,7 +194,7 @@ def _history_handler(grab_ids, id_field: str):
 
 
 def _prime_arr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=(),
-               id_field="movieId") -> None:
+               id_field="movieId", free_space=None) -> None:
     server.expect_request("/api/v3/wanted/missing").respond_with_json(
         {"records": [_missing_record(m) for m in missing]})
     server.expect_request("/api/v3/wanted/cutoff").respond_with_json(
@@ -202,6 +204,10 @@ def _prime_arr(server: HTTPServer, *, missing=(), cutoff=(), queue=(), grab_ids=
     server.expect_request(re.compile(r"^/api/v3/queue/\d+$"), method="DELETE").respond_with_json({})
     server.expect_request("/api/v3/history/since").respond_with_handler(
         _history_handler(grab_ids, id_field))
+    # rootfolder feeds the space guard; free_space=None => no accessible reading (guard fails open).
+    server.expect_request("/api/v3/rootfolder").respond_with_json(
+        [] if free_space is None
+        else [{"path": "/data", "accessible": True, "freeSpace": free_space}])
 
 
 def deletes(server: HTTPServer) -> list:

--- a/stacks/apps/warden/app/tests/integration/test_warden_e2e.py
+++ b/stacks/apps/warden/app/tests/integration/test_warden_e2e.py
@@ -266,6 +266,53 @@ def test_grab_efficacy_records_hits_and_misses(launch, radarr_server, sonarr_ser
     assert miss and miss >= 1.0, "warden never recorded a miss for the never-grabbed item"
 
 
+GB = 1_000_000_000
+
+
+def test_low_disk_pauses_hunting_but_keeps_janitor(launch, radarr_server, sonarr_server):
+    # only 5 GB free, floor is 50 GB -> hunting is space-blocked, but the loop keeps
+    # ticking (janitor is decoupled from the space gate, same as the quota gate).
+    prime_radarr(radarr_server, missing=[(11, "Dune"), (12, "Heat")], free_space=5 * GB)
+    prime_sonarr(sonarr_server, missing=[])
+    warden = launch(**_env(radarr_server, sonarr_server), WARDEN_MIN_FREE_GB="50")
+
+    blocked = poll_until(lambda: sample(scrape(warden), "warden_space_blocked", source="radarr") == 1.0)
+    assert blocked
+    assert commands(radarr_server) == []
+    assert sample(scrape(warden), "warden_space_paused_ticks_total", source="radarr") >= 1.0
+    # loop keeps ticking while space-blocked (last_tick advances)
+    t1 = sample(scrape(warden), "warden_last_tick_timestamp_seconds")
+    assert poll_until(lambda: (sample(scrape(warden), "warden_last_tick_timestamp_seconds") or 0) > t1,
+                      timeout=10)
+
+
+def test_in_flight_queue_counts_against_headroom(launch, radarr_server, sonarr_server):
+    # 100 GB free looks fine against a 50 GB floor, but 80 GB is still downloading in the
+    # queue -> projected headroom (20 GB) is under the floor, so hunting is blocked.
+    huge = {"id": 90, "movieId": 11, "title": "big", "status": "downloading",
+            "errorMessage": None, "added": "2026-06-18T00:00:00Z",
+            "downloadId": "DL90", "size": 80 * GB, "sizeleft": 80 * GB}
+    prime_radarr(radarr_server, missing=[(11, "Dune"), (13, "Other")], queue=[huge],
+                 free_space=100 * GB)
+    prime_sonarr(sonarr_server, missing=[])
+    warden = launch(**_env(radarr_server, sonarr_server), WARDEN_MIN_FREE_GB="50")
+
+    blocked = poll_until(lambda: sample(scrape(warden), "warden_space_blocked", source="radarr") == 1.0)
+    assert blocked
+    assert commands(radarr_server) == []
+
+
+def test_ample_disk_still_hunts(launch, radarr_server, sonarr_server):
+    prime_radarr(radarr_server, missing=[(11, "Dune")], free_space=500 * GB)
+    prime_sonarr(sonarr_server, missing=[])
+    warden = launch(**_env(radarr_server, sonarr_server), WARDEN_MIN_FREE_GB="50")
+    issued = poll_until(lambda: commands(radarr_server))
+    assert issued and issued[0]["name"] == "MoviesSearch"
+    text = scrape(warden)
+    assert sample(text, "warden_space_blocked", source="radarr") == 0.0
+    assert sample(text, "warden_free_bytes", source="radarr") == float(500 * GB)
+
+
 def test_unfindable_item_is_backed_off(launch, radarr_server, sonarr_server):
     # a never-grabbed item that misses (threshold=1) earns a cooldown and drops out of hunting.
     prime_radarr(radarr_server, missing=[])

--- a/stacks/apps/warden/app/tests/unit/clients/test_arr.py
+++ b/stacks/apps/warden/app/tests/unit/clients/test_arr.py
@@ -166,6 +166,36 @@ class TestRadarrQueue:
         assert seen["params"] == {"removeFromClient": "true", "blocklist": "true"}
 
 
+class TestRootFolders:
+    async def test_list_root_folders_maps_path_and_free_space(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v3/rootfolder"
+            assert request.headers["X-Api-Key"] == "rk"
+            return httpx.Response(200, json=[
+                {"id": 1, "path": "/movies", "accessible": True, "freeSpace": 123456789},
+                {"id": 2, "path": "/movies4k", "accessible": True, "freeSpace": 42},
+            ])
+
+        client = RadarrClient(name="radarr", base_url="http://radarr",
+                              http=httpx.AsyncClient(transport=transport(handler)), api_key="rk")
+        folders = await client.list_root_folders()
+        assert [(f.path, f.free_space) for f in folders] == [("/movies", 123456789), ("/movies4k", 42)]
+
+    async def test_list_root_folders_skips_inaccessible_without_free_space(self):
+        # an inaccessible root folder reports no freeSpace -> excluded (no space reading)
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[
+                {"id": 1, "path": "/ok", "accessible": True, "freeSpace": 100},
+                {"id": 2, "path": "/gone", "accessible": False},
+                {"id": 3, "path": "/null", "accessible": False, "freeSpace": None},
+            ])
+
+        client = RadarrClient(name="radarr", base_url="http://radarr",
+                              http=httpx.AsyncClient(transport=transport(handler)), api_key="rk")
+        folders = await client.list_root_folders()
+        assert [(f.path, f.free_space) for f in folders] == [("/ok", 100)]
+
+
 class TestRadarrHistory:
     async def test_list_grabbed_since_maps_events_and_date_param(self):
         seen = {}

--- a/stacks/apps/warden/app/tests/unit/services/test_orchestrator.py
+++ b/stacks/apps/warden/app/tests/unit/services/test_orchestrator.py
@@ -14,6 +14,7 @@ from warden.services.planner import HuntPlanner
 from warden.services.quota import QuotaLedger
 from warden.services.quota_source import FallbackQuotaSource
 from warden.services.progress import ProgressTracker
+from warden.services.space import SpaceGuard
 from warden.services.backoff import BackoffTracker
 from warden.services.efficacy import EfficacyTracker
 from warden.services.stale import StaleDetector
@@ -47,6 +48,7 @@ def _make_orch(clients, repo: SearchLedgerRepository) -> TickOrchestrator:
         metrics=Metrics(CollectorRegistry()),
         schedule=schedule,
         quota_source=FallbackQuotaSource(),
+        space_guard=SpaceGuard(0),
         include_cutoff_unmet=True,
         fallback_per_day=200,
         prowlarr_fallback_on_error=True,

--- a/stacks/apps/warden/app/tests/unit/services/test_space.py
+++ b/stacks/apps/warden/app/tests/unit/services/test_space.py
@@ -1,0 +1,54 @@
+from collections.abc import Callable
+
+import pytest
+
+from warden.models import RootFolder
+from warden.services.space import SpaceGuard, SpaceVerdict
+
+GB = 1_000_000_000
+
+
+class TestSpaceGuard:
+    @pytest.fixture()
+    def make(self) -> Callable[[int], SpaceGuard]:
+        return lambda min_gb: SpaceGuard(min_free_bytes=min_gb * GB)
+
+    def test_disabled_when_floor_is_zero(self, make):
+        assert make(0).enabled is False
+
+    def test_enabled_when_floor_is_positive(self, make):
+        assert make(50).enabled is True
+
+    def test_no_readings_returns_none_so_caller_fails_open(self, make):
+        assert make(50).evaluate([], committed_bytes=0) is None
+
+    def test_blocks_when_free_below_floor(self, make):
+        verdict = make(50).evaluate([RootFolder("/data", 5 * GB)], committed_bytes=0)
+        assert verdict == SpaceVerdict(blocked=True, free_bytes=5 * GB, projected_bytes=5 * GB,
+                                       path="/data")
+
+    def test_allows_when_free_at_or_above_floor(self, make):
+        # exactly at the floor is allowed (block is strictly-below)
+        verdict = make(50).evaluate([RootFolder("/data", 50 * GB)], committed_bytes=0)
+        assert verdict.blocked is False
+        assert verdict.projected_bytes == 50 * GB
+
+    def test_uses_smallest_free_space_across_root_folders(self, make):
+        verdict = make(50).evaluate(
+            [RootFolder("/a", 500 * GB), RootFolder("/b", 10 * GB)], committed_bytes=0)
+        assert verdict.blocked is True
+        assert verdict.free_bytes == 10 * GB
+        assert verdict.path == "/b"          # verdict identifies the tightest folder
+
+    def test_in_flight_queue_subtracts_from_headroom(self, make):
+        # 100 GB free clears the 50 GB floor, but 80 GB still downloading pushes projected
+        # headroom to 20 GB -> blocked.
+        verdict = make(50).evaluate([RootFolder("/data", 100 * GB)], committed_bytes=80 * GB)
+        assert verdict.blocked is True
+        assert verdict.free_bytes == 100 * GB
+        assert verdict.projected_bytes == 20 * GB
+
+    def test_projected_headroom_can_go_negative(self, make):
+        verdict = make(10).evaluate([RootFolder("/data", 5 * GB)], committed_bytes=8 * GB)
+        assert verdict.blocked is True
+        assert verdict.projected_bytes == -3 * GB

--- a/stacks/apps/warden/app/tests/unit/services/test_tick.py
+++ b/stacks/apps/warden/app/tests/unit/services/test_tick.py
@@ -6,7 +6,7 @@ from prometheus_client import CollectorRegistry
 
 from warden.clock import SystemClock
 from warden.metrics import Metrics
-from warden.models import ArrType, GrabEvent, QueueItem, SourceQuota
+from warden.models import ArrType, GrabEvent, QueueItem, RootFolder, SourceQuota
 from warden.repositories.ledger import SearchLedgerRepository
 from warden.schedule import ResetSchedule
 from warden.services.backoff import BackoffTracker
@@ -17,6 +17,7 @@ from warden.services.planner import HuntPlanner
 from warden.services.quota import QuotaLedger
 from warden.services.quota_source import FallbackQuotaSource
 from warden.services.progress import ProgressTracker
+from warden.services.space import SpaceGuard
 from warden.services.stale import StaleDetector
 from warden.services.sweeper import QueueSweeper
 from tests.factories import (
@@ -51,6 +52,7 @@ class FrozenClock(SystemClock):
 
 
 NOON = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+GB = 1_000_000_000
 
 
 class StubQuotaSource:
@@ -79,7 +81,7 @@ class TestTickOrchestrator:
     def make(self, repo: SearchLedgerRepository) -> Callable[..., tuple[TickOrchestrator, Metrics]]:
         def _make(clients, *, quota_source=None, fallback=200, reserve=20, poll=300, when=NOON,
                   prowlarr_fallback_on_error=True, progress_repo=None, efficacy_repo=None,
-                  efficacy=None, backoff=None, backoff_repo=None):
+                  efficacy=None, backoff=None, backoff_repo=None, space_guard=None):
             schedule = ResetSchedule("00:00")
             metrics = Metrics(CollectorRegistry())
             orch = TickOrchestrator(
@@ -99,6 +101,7 @@ class TestTickOrchestrator:
                 metrics=metrics,
                 schedule=schedule,
                 quota_source=quota_source or FallbackQuotaSource(),
+                space_guard=space_guard or SpaceGuard(0),
                 include_cutoff_unmet=True,
                 fallback_per_day=fallback,
                 poll_interval_sec=poll,
@@ -399,3 +402,83 @@ class TestTickOrchestrator:
         searched = [i for batch in radarr.searched for i in batch]
         assert 7 in searched                          # disabled -> active() not consulted
         assert boff.streaks("radarr", [8]) == {}      # disabled -> no streak recorded for the miss
+
+    async def test_space_blocked_skips_hunt_but_janitor_still_sweeps(self, make):
+        # low disk pauses hunting, but the sweep (which costs no space) still runs.
+        radarr = FakeArrClient(
+            "radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+            root_folders=[RootFolder("/data", 5 * GB)],
+            queue=[QueueItem(id=11, remote_id=2, title="s", status="warning",
+                             error_message="stalled with no connections", added=NOON - timedelta(hours=72))])
+        orch, metrics = make([radarr], space_guard=SpaceGuard(50 * GB))
+        decision = await orch.tick()
+        assert radarr.searched == []          # hunting paused
+        assert radarr.removed == [11]         # janitor still swept
+        assert decision.reason == "blocked"
+        reg = metrics.registry
+        assert reg.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 1
+        assert reg.get_sample_value("warden_space_paused_ticks_total", {"source": "radarr"}) == 1
+
+    async def test_ample_space_hunts_and_publishes_headroom(self, make):
+        radarr = FakeArrClient("radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+                               root_folders=[RootFolder("/data", 500 * GB)])
+        orch, metrics = make([radarr], space_guard=SpaceGuard(50 * GB))
+        await orch.tick()
+        assert radarr.searched == [[1]]
+        reg = metrics.registry
+        assert reg.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 0
+        assert reg.get_sample_value("warden_free_bytes", {"source": "radarr"}) == 500 * GB
+        assert reg.get_sample_value("warden_projected_free_bytes", {"source": "radarr"}) == 500 * GB
+
+    async def test_in_flight_queue_pushes_headroom_below_floor_and_blocks(self, make):
+        # 100 GB free clears the 50 GB floor, but 80 GB in flight -> 20 GB projected -> blocked.
+        radarr = FakeArrClient(
+            "radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+            root_folders=[RootFolder("/data", 100 * GB)],
+            queue=[QueueItem(id=90, remote_id=2, title="big", status="downloading",
+                             error_message="", added=NOON - timedelta(hours=1),
+                             download_id="DL90", size_left=80 * GB)])
+        orch, metrics = make([radarr], space_guard=SpaceGuard(50 * GB))
+        await orch.tick()
+        assert radarr.searched == []
+        reg = metrics.registry
+        assert reg.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 1
+        assert reg.get_sample_value("warden_projected_free_bytes", {"source": "radarr"}) == 20 * GB
+
+    async def test_space_read_error_fails_open(self, make):
+        radarr = FakeArrClient("radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+                               root_folders_raises=True)
+        orch, metrics = make([radarr], space_guard=SpaceGuard(50 * GB))
+        await orch.tick()
+        assert radarr.searched == [[1]]       # unreadable space -> hunt anyway
+        assert metrics.registry.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 0
+
+    async def test_no_root_folder_readings_fails_open(self, make):
+        radarr = FakeArrClient("radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+                               root_folders=[])
+        orch, _ = make([radarr], space_guard=SpaceGuard(50 * GB))
+        await orch.tick()
+        assert radarr.searched == [[1]]
+
+    async def test_space_block_is_per_source(self, make):
+        # radarr's disk is low, sonarr's is fine -> only radarr pauses; sonarr keeps hunting.
+        radarr = FakeArrClient("radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+                               root_folders=[RootFolder("/movies", 5 * GB)])
+        sonarr = FakeArrClient("sonarr", [missing_item("sonarr", 9)], arr_type=ArrType.SONARR,
+                               root_folders=[RootFolder("/tv", 500 * GB)])
+        orch, metrics = make([radarr, sonarr], space_guard=SpaceGuard(50 * GB))
+        await orch.tick()
+        assert radarr.searched == []
+        assert sonarr.searched == [[9]]
+        reg = metrics.registry
+        assert reg.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 1
+        assert reg.get_sample_value("warden_space_blocked", {"source": "sonarr"}) == 0
+
+    async def test_guard_disabled_never_reads_root_folders(self, make):
+        # a floor of 0 disables the guard; the root folder endpoint is never consulted.
+        radarr = FakeArrClient("radarr", [missing_item("radarr", 1)], arr_type=ArrType.RADARR,
+                               root_folders=[RootFolder("/data", 1)])   # would block if read
+        orch, _ = make([radarr])   # default SpaceGuard(0)
+        await orch.tick()
+        assert radarr.searched == [[1]]
+        assert radarr.root_folder_calls == 0

--- a/stacks/apps/warden/app/tests/unit/test_config.py
+++ b/stacks/apps/warden/app/tests/unit/test_config.py
@@ -85,6 +85,24 @@ class TestConfig:
         assert Config.from_env().prowlarr_fallback_on_error is False
 
 
+class TestSpaceGuardConfig:
+    def test_disabled_by_default_when_env_absent(self, monkeypatch):
+        monkeypatch.delenv("WARDEN_MIN_FREE_GB", raising=False)
+        assert Config.from_env().min_free_bytes == 0
+
+    def test_empty_env_disables_the_guard(self, monkeypatch):
+        monkeypatch.setenv("WARDEN_MIN_FREE_GB", "")
+        assert Config.from_env().min_free_bytes == 0
+
+    def test_gb_value_converts_to_bytes(self, monkeypatch):
+        monkeypatch.setenv("WARDEN_MIN_FREE_GB", "50")
+        assert Config.from_env().min_free_bytes == 50_000_000_000
+
+    def test_fractional_gb_supported(self, monkeypatch):
+        monkeypatch.setenv("WARDEN_MIN_FREE_GB", "0.5")
+        assert Config.from_env().min_free_bytes == 500_000_000
+
+
 class TestStaleConfig:
     def test_stale_defaults(self, monkeypatch):
         for v in ("WARDEN_STALE_SWEEP_ENABLED", "WARDEN_STALE_GRACE_HOURS",

--- a/stacks/apps/warden/app/tests/unit/test_metrics.py
+++ b/stacks/apps/warden/app/tests/unit/test_metrics.py
@@ -47,6 +47,21 @@ class TestMetrics:
             "warden_last_tick_timestamp_seconds", {}) == 1718700000.0
 
 
+def test_space_metrics_exist():
+    from prometheus_client import CollectorRegistry
+    from warden.metrics import Metrics
+    m = Metrics(CollectorRegistry())
+    m.space_blocked.labels(source="radarr").set(1)
+    m.space_paused_ticks.labels(source="radarr").inc()
+    m.free_bytes.labels(source="radarr").set(500_000_000_000)
+    m.projected_free_bytes.labels(source="radarr").set(420_000_000_000)
+    reg = m.registry
+    assert reg.get_sample_value("warden_space_blocked", {"source": "radarr"}) == 1
+    assert reg.get_sample_value("warden_space_paused_ticks_total", {"source": "radarr"}) == 1
+    assert reg.get_sample_value("warden_free_bytes", {"source": "radarr"}) == 500_000_000_000
+    assert reg.get_sample_value("warden_projected_free_bytes", {"source": "radarr"}) == 420_000_000_000
+
+
 def test_stale_metrics_exist():
     from prometheus_client import CollectorRegistry
     from warden.metrics import Metrics

--- a/stacks/apps/warden/app/warden/clients/arr.py
+++ b/stacks/apps/warden/app/warden/clients/arr.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-from warden.models import ArrType, GrabEvent, QueueItem, WantedItem, WantKind
+from warden.models import ArrType, GrabEvent, QueueItem, RootFolder, WantedItem, WantKind
 
 
 def _parse_iso(raw: str | None) -> datetime | None:
@@ -118,6 +118,20 @@ class ArrClient(ABC):
             params={"removeFromClient": str(remove_from_client).lower(),
                     "blocklist": str(blocklist).lower()})
         resp.raise_for_status()
+
+    async def list_root_folders(self) -> list[RootFolder]:
+        """Free space per configured library root folder. Inaccessible folders report no
+        freeSpace and are omitted, so callers only see real readings. This endpoint is a
+        flat array (not paged)."""
+        resp = await self._http.get(f"{self._base}/api/v3/rootfolder", headers=self._headers)
+        resp.raise_for_status()
+        folders: list[RootFolder] = []
+        for r in resp.json():
+            free = r.get("freeSpace")
+            if free is None:
+                continue                          # inaccessible root folder — no reading
+            folders.append(RootFolder(path=r.get("path", ""), free_space=int(free)))
+        return folders
 
     async def list_grabbed_since(self, since: datetime) -> list[GrabEvent]:
         resp = await self._http.get(

--- a/stacks/apps/warden/app/warden/config.py
+++ b/stacks/apps/warden/app/warden/config.py
@@ -14,6 +14,15 @@ def _env_bool(name: str, default: bool) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _min_free_bytes_from_env() -> int:
+    """Space-guard floor from WARDEN_MIN_FREE_GB (GB -> bytes, decimal). Unset or empty
+    means the guard is disabled (0 bytes); there is no baked-in default."""
+    raw = os.getenv("WARDEN_MIN_FREE_GB", "").strip()
+    if not raw:
+        return 0
+    return int(float(raw) * 1_000_000_000)
+
+
 def _instances_from_env() -> Iterator[InstanceConfig]:
     """Discover configured *arr instances from env vars.
 
@@ -59,6 +68,7 @@ class Config:
     backoff_enabled: bool
     backoff_miss_threshold: int
     backoff_cooldown_days: float
+    min_free_bytes: int
 
     @staticmethod
     def from_env() -> "Config":
@@ -90,4 +100,5 @@ class Config:
             backoff_enabled=_env_bool("WARDEN_BACKOFF_ENABLED", True),
             backoff_miss_threshold=int(os.getenv("WARDEN_BACKOFF_MISS_THRESHOLD", "3")),
             backoff_cooldown_days=float(os.getenv("WARDEN_BACKOFF_COOLDOWN_DAYS", "30")),
+            min_free_bytes=_min_free_bytes_from_env(),
         )

--- a/stacks/apps/warden/app/warden/container.py
+++ b/stacks/apps/warden/app/warden/container.py
@@ -26,6 +26,7 @@ from warden.services.planner import HuntPlanner
 from warden.services.quota import QuotaLedger
 from warden.services.quota_source import FallbackQuotaSource, ProwlarrQuotaSource
 from warden.services.progress import ProgressTracker
+from warden.services.space import SpaceGuard
 from warden.services.stale import StaleDetector
 from warden.services.sweeper import QueueSweeper
 
@@ -88,6 +89,7 @@ class Container(containers.DeclarativeContainer):
     )
     pacer = providers.Singleton(Pacer, poll_interval_sec=config.provided.poll_interval_sec)
     planner = providers.Singleton(HuntPlanner)
+    space_guard = providers.Singleton(SpaceGuard, min_free_bytes=config.provided.min_free_bytes)
     detector = providers.Singleton(StaleDetector, grace_hours=config.provided.stale_grace_hours)
     sweeper = providers.Singleton(
         QueueSweeper,
@@ -121,6 +123,7 @@ class Container(containers.DeclarativeContainer):
         metrics=metrics,
         schedule=schedule,
         quota_source=quota_source,
+        space_guard=space_guard,
         include_cutoff_unmet=config.provided.include_cutoff_unmet,
         fallback_per_day=config.provided.fallback_searches_per_day,
         prowlarr_fallback_on_error=config.provided.prowlarr_fallback_on_error,

--- a/stacks/apps/warden/app/warden/metrics.py
+++ b/stacks/apps/warden/app/warden/metrics.py
@@ -30,6 +30,19 @@ class Metrics:
             ["source"], registry=registry)
         self.blocked = Gauge(
             "warden_blocked", "1 when a source is quota-paused", ["source"], registry=registry)
+        self.space_blocked = Gauge(
+            "warden_space_blocked", "1 when a source is space-paused (low disk headroom)",
+            ["source"], registry=registry)
+        self.space_paused_ticks = Counter(
+            "warden_space_paused_ticks_total",
+            "Ticks a source was space-paused (× poll interval ≈ paused time)",
+            ["source"], registry=registry)
+        self.free_bytes = Gauge(
+            "warden_free_bytes", "Smallest free space across the source's *arr root folders",
+            ["source"], registry=registry)
+        self.projected_free_bytes = Gauge(
+            "warden_projected_free_bytes", "Free bytes minus in-flight queue size_left (hunt headroom)",
+            ["source"], registry=registry)
         self.instance_up = Gauge(
             "warden_instance_up", "1 when the *arr source responded this tick", ["source"], registry=registry)
         self.prowlarr_up = Gauge(

--- a/stacks/apps/warden/app/warden/models.py
+++ b/stacks/apps/warden/app/warden/models.py
@@ -46,6 +46,13 @@ class QueueItem:
 
 
 @dataclass(frozen=True)
+class RootFolder:
+    """An *arr library root folder and the free space on its filesystem (bytes)."""
+    path: str
+    free_space: int
+
+
+@dataclass(frozen=True)
 class Anchor:
     """No-progress checkpoint: a download's bytes-remaining at a point in time."""
     size_left: int
@@ -136,6 +143,7 @@ class ArrClientProtocol(Protocol):
     async def remove_queue_item(self, queue_id: int, *, remove_from_client: bool = True,
                                 blocklist: bool = True) -> None: ...
     async def list_grabbed_since(self, since: datetime) -> list["GrabEvent"]: ...
+    async def list_root_folders(self) -> list["RootFolder"]: ...
 
 
 class ProwlarrReader(Protocol):

--- a/stacks/apps/warden/app/warden/services/orchestrator.py
+++ b/stacks/apps/warden/app/warden/services/orchestrator.py
@@ -19,6 +19,7 @@ from warden.services.pacer import Pacer
 from warden.services.planner import HuntPlanner
 from warden.services.progress import ProgressTracker
 from warden.services.quota import QuotaLedger
+from warden.services.space import SpaceGuard, SpaceVerdict
 from warden.services.stale import StaleVerdict
 from warden.services.sweeper import QueueSweeper
 
@@ -44,6 +45,7 @@ class TickOrchestrator:
         metrics: Metrics,
         schedule: ResetSchedule,
         quota_source: QuotaSource,
+        space_guard: SpaceGuard,
         include_cutoff_unmet: bool,
         fallback_per_day: int,
         prowlarr_fallback_on_error: bool,
@@ -65,6 +67,7 @@ class TickOrchestrator:
         self._metrics = metrics
         self._schedule = schedule
         self._quota_source = quota_source
+        self._space_guard = space_guard
         self._include_cutoff = include_cutoff_unmet
         self._fallback_per_day = fallback_per_day
         self._prowlarr_fallback_on_error = prowlarr_fallback_on_error
@@ -121,6 +124,8 @@ class TickOrchestrator:
                     _logger.info("source quota-blocked", extra={"event": "blocked", "source": src, "budget": state.daily_budget, "spent": spent, "mode": "prowlarr" if is_prowlarr else "fallback"})
                     continue
                 m.blocked.labels(source=src).set(0)
+                if await self._space_blocked(client, queue):
+                    continue
                 all_blocked = False
                 allowance = self._pacer.allowance(state.remaining, seconds_to_reset)
                 if self._backoff.enabled:
@@ -159,6 +164,43 @@ class TickOrchestrator:
         m.indexers_total.labels(source=src).set(total)
         m.indexers_defaulted.labels(source=src).set(defaulted)
         return state, is_prowlarr, spent
+
+    async def _space_blocked(self, client: ArrClientProtocol, queue: list[QueueItem]) -> bool:
+        """When the space guard is enabled, pause hunting if the disk's projected headroom
+        (min free across root folders, minus bytes still downloading) is below the floor.
+        Fails open: any unreadable space (fetch error or no accessible root folder) hunts
+        anyway, consistent with warden's other degrade-don't-block behaviours."""
+        if not self._space_guard.enabled:
+            return False
+        m = self._metrics
+        src = client.name
+        verdict = await self._space_verdict(client, queue)
+        if verdict is not None:
+            m.free_bytes.labels(source=src).set(verdict.free_bytes)
+            m.projected_free_bytes.labels(source=src).set(verdict.projected_bytes)
+        blocked = bool(verdict and verdict.blocked)
+        m.space_blocked.labels(source=src).set(1 if blocked else 0)
+        if blocked:
+            m.space_paused_ticks.labels(source=src).inc()
+            _logger.info("source space-blocked", extra={"event": "space_blocked", "source": src,
+                "path": verdict.path, "free_bytes": verdict.free_bytes,
+                "projected_bytes": verdict.projected_bytes})
+        return blocked
+
+    async def _space_verdict(self, client: ArrClientProtocol,
+                             queue: list[QueueItem]) -> SpaceVerdict | None:
+        """Fetch root-folder free space and evaluate the guard. Returns None when space is
+        unreadable (fetch error, or no accessible root folder) so the caller fails open."""
+        try:
+            root_folders = await client.list_root_folders()
+        except Exception as exc:  # noqa: BLE001 - space unreadable; hunt anyway
+            _logger.warning("root folder space unreachable; hunting anyway",
+                            extra={"event": "space_unreachable", "source": client.name, "error": str(exc)})
+            return None
+        # Pre-sweep queue snapshot: items removed this tick still count toward committed,
+        # which only makes the guard slightly more conservative (never under-blocks).
+        committed = sum(q.size_left for q in queue)
+        return self._space_guard.evaluate(root_folders, committed)
 
     async def _sweep(self, client: ArrClientProtocol, queue: list[QueueItem], now: datetime,
                      extra: list[StaleVerdict]) -> set[int]:

--- a/stacks/apps/warden/app/warden/services/space.py
+++ b/stacks/apps/warden/app/warden/services/space.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from warden.models import RootFolder
+
+
+@dataclass(frozen=True)
+class SpaceVerdict:
+    blocked: bool
+    free_bytes: int         # smallest free space across the source's root folders
+    projected_bytes: int    # free_bytes minus bytes still downloading in the queue
+    path: str               # the tightest root folder (the one free_bytes came from)
+
+
+class SpaceGuard:
+    """Decides whether low disk should pause hunting.
+
+    Projected headroom = the smallest free space across a source's *arr root folders,
+    minus the bytes still downloading in its queue (in-flight grabs that haven't landed
+    yet). Hunting is blocked when that headroom falls below the configured floor, so
+    warden stops asking for new releases before the disk actually fills.
+
+    A floor of 0 disables the guard. When no root folder reports free space (all
+    inaccessible), ``evaluate`` returns ``None`` so the caller can fail open.
+    """
+
+    def __init__(self, min_free_bytes: int) -> None:
+        self._min = min_free_bytes
+
+    @property
+    def enabled(self) -> bool:
+        return self._min > 0
+
+    def evaluate(self, root_folders: list[RootFolder], committed_bytes: int) -> SpaceVerdict | None:
+        if not root_folders:
+            return None
+        tightest = min(root_folders, key=lambda rf: rf.free_space)
+        projected = tightest.free_space - committed_bytes
+        return SpaceVerdict(blocked=projected < self._min, free_bytes=tightest.free_space,
+                            projected_bytes=projected, path=tightest.path)

--- a/stacks/apps/warden/docker-compose.yml
+++ b/stacks/apps/warden/docker-compose.yml
@@ -20,6 +20,9 @@ services:
             - WARDEN_FALLBACK_SEARCHES_PER_DAY=${WARDEN_FALLBACK_SEARCHES_PER_DAY:-200}
             - WARDEN_RESET_AT_LOCAL=${WARDEN_RESET_AT_LOCAL:-00:00}
             - WARDEN_POLL_INTERVAL_SEC=${WARDEN_POLL_INTERVAL_SEC:-300}
+            # Space guard: pause hunting when projected free disk (min root-folder free
+            # minus in-flight queue) drops below this many GB. Unset = guard disabled.
+            - WARDEN_MIN_FREE_GB=${WARDEN_MIN_FREE_GB:-}
             # Optional: point at Prowlarr to derive per-source budgets from real
             # indexer query limits (omit to use the flat fallback budget).
             - WARDEN_PROWLARR_URL=${WARDEN_PROWLARR_URL:-}


### PR DESCRIPTION
## What

Adds an opt-in **space guard** to warden that pauses hunting when the disk is running low, so it stops asking Radarr/Sonarr for new releases before the drive fills.

Each tick, per source, warden reads the smallest free space across the instance's `*arr` root folders and subtracts the bytes still downloading in that source's queue (in-flight grabs that haven't landed). If that **projected headroom** falls below `WARDEN_MIN_FREE_GB`, hunting is skipped for the tick. The janitor (sweep / no-progress / efficacy) still runs, so a full disk keeps getting cleaned while hunting is paused — same decoupling as the existing quota gate.

## Behaviour

- **Off unless `WARDEN_MIN_FREE_GB` is set** — no default floor.
- **Fails open** — if root-folder free space can't be read (endpoint error, or all folders inaccessible), warden hunts anyway rather than freeze, consistent with the Prowlarr/instance degrade-don't-block behaviour.
- **Queue-aware** — reuses `QueueItem.size_left`, so in-flight downloads count against headroom.
- **Per source** — one source can be space-blocked while another keeps hunting.

## Design

- Outer ring: `ArrClient.list_root_folders()` (`GET /api/v3/rootfolder`), behind the existing `ArrClientProtocol`.
- Inner ring: pure `SpaceGuard` service (imports only models) — picks the tightest root folder, returns a `SpaceVerdict` (or `None` = fail open).
- Gate wired into `TickOrchestrator` beside the quota-blocked branch.
- New metrics: `warden_space_blocked`, `warden_free_bytes`, `warden_projected_free_bytes`, `warden_space_paused_ticks_total`.

## Tests

Outside-in TDD. 186 unit tests @ 100% coverage, 20 integration tests (real warden process vs fake `*arr`), import-linter (Circle Architecture) kept.

## Deploy note

Not activated by this PR — the running warden image predates this code, so it needs the usual version bump + rebuild + redeploy. `WARDEN_MIN_FREE_GB` documented in `.env.example` and the compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)