### PR TITLE
feat: wire librenms, photoprism, and postal mariadb databases into fiber and pin fiber image to 3.24.0

### DIFF
--- a/stacks/apps/fiber/docker-compose.yml
+++ b/stacks/apps/fiber/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     fiber:
-        image: ${REGISTRY:-ghcr.io}/${REGISTRY_NAMESPACE:-chutch3}/fiber:${IMAGE_TAG:-3.21.0}
+        image: ${REGISTRY:-ghcr.io}/${REGISTRY_NAMESPACE:-chutch3}/fiber:${IMAGE_TAG:-3.24.0}
         build:
             context: .
             dockerfile: app/Dockerfile
@@ -31,6 +31,9 @@ services:
             - librechat_db_password
             - immich_db_password
             - authentik_db_password
+            - librenms_db_password
+            - photoprism_db_password
+            - postal_db_password
         deploy:
             replicas: 1
             placement:
@@ -81,6 +84,12 @@ secrets:
     immich_db_password:
         external: true
     authentik_db_password:
+        external: true
+    librenms_db_password:
+        external: true
+    photoprism_db_password:
+        external: true
+    postal_db_password:
         external: true
 
 volumes:

--- a/stacks/apps/librenms/docker-compose.yml
+++ b/stacks/apps/librenms/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       start_period: 30s
     networks:
       - librenms-internal
+      - backups
     deploy:
       placement:
         constraints:
@@ -32,6 +33,14 @@ services:
       restart_policy:
         condition: any
         delay: 5s
+      labels:
+        - "fiber.enable=true"
+        - "fiber.provider=swarm"
+        - "fiber.engine=mysql"
+        - "fiber.dbname=librenms"
+        - "fiber.user=librenms"
+        - "fiber.secret=librenms_db_password"
+        - "fiber.schedule=0 3 * * *"
 
   redis:
     image: redis:7.2-alpine
@@ -219,6 +228,8 @@ networks:
   librenms-internal:
     driver: overlay
   traefik-public:
+    external: true
+  backups:
     external: true
 
 volumes:

--- a/stacks/apps/librenms/pre-flight.yml
+++ b/stacks/apps/librenms/pre-flight.yml
@@ -1,3 +1,8 @@
+# Create the swarm secret Fiber reads to dump this DB.
+secrets:
+  - name: librenms_db_password
+    from_env: LIBRENMS_DB_PASSWORD
+
 validate:
   env:
     - LIBRENMS_DB_PASSWORD

--- a/stacks/apps/photoprism/docker-compose.yml
+++ b/stacks/apps/photoprism/docker-compose.yml
@@ -111,8 +111,17 @@ services:
                 constraints:
                     # Centralized database node for all databases
                     - node.labels.database == true
+            labels:
+                - "fiber.enable=true"
+                - "fiber.provider=swarm"
+                - "fiber.engine=mysql"
+                - "fiber.dbname=photoprism"
+                - "fiber.user=photoprism"
+                - "fiber.secret=photoprism_db_password"
+                - "fiber.schedule=0 3 * * *"
         networks:
             - traefik-public
+            - backups
 
     ## Ollama Large-Language Model Runner (optional)
     ## Run "ollama pull [name]:[version]" to download a vision model
@@ -165,6 +174,8 @@ services:
 
 networks:
     traefik-public:
+        external: true
+    backups:
         external: true
 
 volumes:

--- a/stacks/apps/photoprism/pre-flight.yml
+++ b/stacks/apps/photoprism/pre-flight.yml
@@ -1,0 +1,8 @@
+# Create the swarm secret Fiber reads to dump this DB.
+secrets:
+  - name: photoprism_db_password
+    from_env: PHOTOPRISM_DB_PASSWORD
+
+validate:
+  env:
+    - PHOTOPRISM_DB_PASSWORD

--- a/stacks/apps/postal/docker-compose.yml
+++ b/stacks/apps/postal/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       start_period: 30s
     networks:
       - postal-internal
+      - backups
     deploy:
       placement:
         constraints:
@@ -58,6 +59,17 @@ services:
       restart_policy:
         condition: any
         delay: 5s
+      labels:
+        # Fiber dumps the `postal` control DB (servers, domains, routing, creds).
+        # NOTE: postal also creates one DB per mail server (postal-server-*) for
+        # message data — those are NOT captured by this single-DB dump.
+        - "fiber.enable=true"
+        - "fiber.provider=swarm"
+        - "fiber.engine=mysql"
+        - "fiber.dbname=postal"
+        - "fiber.user=root"
+        - "fiber.secret=postal_db_password"
+        - "fiber.schedule=0 3 * * *"
 
   web:
     image: ghcr.io/postalserver/postal:3.3.7
@@ -156,6 +168,8 @@ networks:
   postal-internal:
     driver: overlay
   traefik-public:
+    external: true
+  backups:
     external: true
 
 volumes:

--- a/stacks/apps/postal/pre-flight.yml
+++ b/stacks/apps/postal/pre-flight.yml
@@ -1,3 +1,8 @@
+# Create the swarm secret Fiber reads to dump this DB.
+secrets:
+  - name: postal_db_password
+    from_env: POSTAL_DB_PASSWORD
+
 validate:
   env:
     - POSTAL_DB_PASSWORD

--- a/tests/ansible/unit/inventory/group_vars/all.yml
+++ b/tests/ansible/unit/inventory/group_vars/all.yml
@@ -45,6 +45,7 @@ swarm_env_vars:
   RSTUDIO_PASSWORD: "test-password"
   IMMICH_DB_PASSWORD: "test-password"
   AUTHENTIK_POSTGRES_PASSWORD: "test-password"
+  PHOTOPRISM_DB_PASSWORD: "test-password"
   POSTAL_DB_PASSWORD: "test-password"
   POSTAL_SECRET_KEY: "test-secret"
   SMTP2GO_USERNAME: "test-user"


### PR DESCRIPTION
## What

Wires the three MariaDB databases into Fiber's label-driven discovery, and pins the Fiber image to **3.24.0** (the release that added MySQL support) so the deployed Fiber can actually probe/dump them.

### DB wiring (mirrors the existing labeled-Postgres pattern)
Each DB service joins the `backups` overlay network and gets a `fiber.*` label block (engine=mysql, plain dumps, `0 3 * * *`), plus a `<name>_db_password` secret created by its pre-flight and granted to the Fiber stack:

| Stack | DB service | dbname | user | secret |
|---|---|---|---|---|
| librenms | `db` (mariadb:10) | librenms | librenms | librenms_db_password |
| photoprism | `mariadb` (mariadb:11) | photoprism | photoprism | photoprism_db_password |
| postal | `db` (mariadb:10.11) | postal | root | postal_db_password |

- photoprism had no `pre-flight.yml` — added one (secret + env validation).
- Added `PHOTOPRISM_DB_PASSWORD` to the preflight-role test fixture so the render test passes.

### Fiber image pin
`stacks/apps/fiber/docker-compose.yml`: `:${IMAGE_TAG:-3.21.0}` → `:${IMAGE_TAG:-3.24.0}`. The running Fiber was 3.21.0 (pre-MySQL), so its Postgres-only `pg_isready` probe failed against MariaDB — this is the "manual bump to deploy" step.

### Known gap (documented inline)
postal spreads data across `postal` + per-server `postal-server-*` DBs; this single-DB dump captures only the `postal` control DB (servers/domains/routing/creds), not the message DBs.

## Deploy order
DB stacks first (create the secrets), then Fiber:
`task ansible:deploy:service -- {librenms,photoprism,postal,fiber}`
