### PR TITLE
ci: run javascript test suites in ci test for any app with a package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,13 @@ jobs:
               with:
                   enable-cache: true
 
+            # For units with a package.json, `ci test` runs their npm test suite
+            # (npm ci + npm run test) — e.g. fiber's browser JS. Harmless for the rest.
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
             # ubuntu-latest ships psql/pg_dump (fiber's pg integration tests use them) but
             # not the MariaDB client tools; fiber's mysql integration tests drive
             # mariadb-dump/mydumper on the runner host. The distro's mydumper is 0.10.1,
@@ -96,7 +103,8 @@ jobs:
               # Runs unit + integration together; the project's --cov-fail-under applies
               # to their COMBINED coverage. e2e is orchestration-heavy and runs separately
               # (e2e.yml / `ci test --tier e2e`). Keyed on the build context so multi-image
-              # stacks test the right subtree; no-ops for units with no pyproject (devbox).
+              # stacks test the right subtree; runs pytest and/or npm test per unit, and
+              # no-ops for units with neither a pyproject nor a package.json (devbox).
               run: uv run ci test "${{ matrix.context }}"
 
     # Always-run required check for tests (mirrors Build gate) — this, not the

--- a/tools/ci/ci/apptests.py
+++ b/tools/ci/ci/apptests.py
@@ -1,9 +1,11 @@
-"""Run the apps' pytest suites by tier — the ``ci test`` subcommand.
+"""Run the apps' test suites by tier — the ``ci test`` subcommand.
 
-Discovery is structural: any dir under ``stacks/`` with a ``pyproject.toml`` is a
-testable project (each declares its own pytest dev-group, so ``uv run pytest``
-self-bootstraps). Tiers are ``tests/{unit,integration,e2e}`` subdirs, run if they
-exist.
+Discovery is structural. A dir under ``stacks/`` with a ``pyproject.toml`` is a Python
+project (each declares its own pytest dev-group, so ``uv run pytest`` self-bootstraps);
+tiers are ``tests/{unit,integration,e2e}`` subdirs, run if they exist. A dir with a
+``package.json`` declaring a ``test`` script is a JS project, run with npm (``npm ci``
+then ``npm run test`` / ``test:<tier>``). An app can be both (e.g. a Python backend with
+a browser-JS frontend), in which case ``ci test`` runs both.
 
 The default (gated) run executes unit + integration **together in one pytest**, so
 the project's ``--cov-fail-under`` applies to the *combined* coverage of both tiers.
@@ -16,6 +18,7 @@ The selection logic is pure and unit-tested; only :func:`run_tests` shells out.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -60,8 +63,8 @@ def tiers_to_run(tier: str | None) -> list[str]:
 
 def run_tests(
     repo_root: str | Path, projects: list[str], tiers: list[str], gated: bool = True, runner=subprocess.run
-) -> int:
-    """Run each project's existing tiers in one pytest invocation. Returns an exit code.
+) -> tuple[int, bool]:
+    """Run each project's existing tiers in one pytest invocation. Returns (exit_code, ran_any).
 
     ``gated`` keeps the project's ``addopts`` so ``--cov-fail-under`` applies to the
     combined coverage of all tiers run together; otherwise ``addopts`` is cleared
@@ -82,6 +85,54 @@ def run_tests(
         result = runner(["uv", "run", "pytest", *paths, *extra], cwd=proj)
         if result.returncode != 0:
             rc = 1
-    if not ran_any:
-        print("No matching test tiers.")
-    return rc
+    return rc, ran_any
+
+
+def js_script_for_tier(tier: str | None) -> str:
+    """The npm script for a tier: gated default suite → ``test``, a tier → ``test:<tier>``."""
+    return "test" if tier is None else f"test:{tier}"
+
+
+def _js_scripts(package_json: Path) -> dict[str, str]:
+    try:
+        return json.loads(package_json.read_text()).get("scripts") or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def discover_js_projects(repo_root: str | Path) -> list[str]:
+    """Repo-relative dirs under stacks/ whose ``package.json`` declares a ``test`` script."""
+    root = Path(repo_root)
+    rels = {
+        p.parent.relative_to(root).as_posix()
+        for p in root.glob("stacks/**/package.json")
+        if "node_modules" not in p.parts and "test" in _js_scripts(p)
+    }
+    return sorted(rels)
+
+
+def run_js_tests(
+    repo_root: str | Path, projects: list[str], tier: str | None, runner=subprocess.run
+) -> tuple[int, bool]:
+    """Run each JS project's npm test script for the tier. Returns (exit_code, ran_any).
+
+    Installs with ``npm ci`` then runs ``npm run <script>`` (``test`` for the default
+    suite, ``test:<tier>`` for an explicit tier). Projects with no such script are
+    skipped, so a JS app only runs the tiers it actually defines.
+    """
+    root = Path(repo_root)
+    script = js_script_for_tier(tier)
+    rc = 0
+    ran_any = False
+    for rel in projects:
+        proj = root / rel
+        if script not in _js_scripts(proj / "package.json"):
+            continue
+        ran_any = True
+        print(f"==> {rel} : npm run {script}")
+        if runner(["npm", "ci"], cwd=proj).returncode != 0:
+            rc = 1
+            continue
+        if runner(["npm", "run", script], cwd=proj).returncode != 0:
+            rc = 1
+    return rc, ran_any

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -25,7 +25,6 @@ def _cmd_affected(args: argparse.Namespace) -> int:
 
 
 def _cmd_test(args: argparse.Namespace) -> int:
-    projects = apptests.discover_test_projects(args.repo_root)
     if args.affected:
         # Test only the projects under the contexts a change vs the base touched.
         diff = subprocess.run(
@@ -33,13 +32,21 @@ def _cmd_test(args: argparse.Namespace) -> int:
             capture_output=True, text=True, check=True,
         ).stdout.split()
         contexts = {entry["context"] for entry in affected.compute_matrix(args.repo_root, diff)}
-        selected = sorted({p for c in contexts for p in apptests.select_projects(projects, c)})
+        pick = lambda ps: sorted({p for c in contexts for p in apptests.select_projects(ps, c)})  # noqa: E731
     else:
-        selected = apptests.select_projects(projects, args.selector)
+        pick = lambda ps: apptests.select_projects(ps, args.selector)  # noqa: E731
+
     # No --tier → the gated default suite (unit+integration, combined coverage).
-    return apptests.run_tests(
-        args.repo_root, selected, apptests.tiers_to_run(args.tier), gated=args.tier is None
+    py_rc, py_ran = apptests.run_tests(
+        args.repo_root, pick(apptests.discover_test_projects(args.repo_root)),
+        apptests.tiers_to_run(args.tier), gated=args.tier is None,
     )
+    js_rc, js_ran = apptests.run_js_tests(
+        args.repo_root, pick(apptests.discover_js_projects(args.repo_root)), args.tier,
+    )
+    if not (py_ran or js_ran):
+        print("No matching test suites.")
+    return py_rc or js_rc
 
 
 def _cmd_images(args: argparse.Namespace) -> int:

--- a/tools/ci/tests/test_apptests.py
+++ b/tools/ci/tests/test_apptests.py
@@ -6,7 +6,10 @@ import textwrap
 from pathlib import Path
 
 from ci.apptests import (
+    discover_js_projects,
     discover_test_projects,
+    js_script_for_tier,
+    run_js_tests,
     run_tests,
     select_projects,
     tiers_to_run,
@@ -83,14 +86,14 @@ def test_gated_run_combines_existing_tiers_in_one_call_keeping_addopts(tmp_path)
     (proj / "tests" / "integration").mkdir(parents=True)
     # no tests/e2e → excluded
     calls: list = []
-    rc = run_tests(tmp_path, ["stacks/apps/warden/app"], ["unit", "integration", "e2e"],
-                   gated=True, runner=_fake_runner(calls))
+    rc, ran = run_tests(tmp_path, ["stacks/apps/warden/app"], ["unit", "integration", "e2e"],
+                        gated=True, runner=_fake_runner(calls))
     assert len(calls) == 1  # one combined invocation
     cmd = calls[0][0]
     assert cmd[:3] == ["uv", "run", "pytest"]
     assert "tests/unit" in cmd and "tests/integration" in cmd and "tests/e2e" not in cmd
     assert "-o" not in cmd  # gated → keep the project's addopts (coverage on the combined run)
-    assert rc == 0
+    assert rc == 0 and ran is True
 
 
 def test_ungated_run_clears_addopts(tmp_path):
@@ -106,6 +109,76 @@ def test_ungated_run_clears_addopts(tmp_path):
 def test_run_tests_propagates_failure(tmp_path):
     proj = tmp_path / "stacks/apps/warden/app"
     (proj / "tests" / "unit").mkdir(parents=True)
-    rc = run_tests(tmp_path, ["stacks/apps/warden/app"], ["unit"],
-                   runner=_fake_runner([], returncode=1))
+    rc, ran = run_tests(tmp_path, ["stacks/apps/warden/app"], ["unit"],
+                        runner=_fake_runner([], returncode=1))
+    assert rc == 1 and ran is True
+
+
+def test_run_tests_reports_nothing_ran_when_no_tiers(tmp_path):
+    (tmp_path / "stacks/apps/warden/app").mkdir(parents=True)  # no tests/ dirs
+    rc, ran = run_tests(tmp_path, ["stacks/apps/warden/app"], ["unit"], runner=_fake_runner([]))
+    assert rc == 0 and ran is False
+
+
+# ---------------------------------------------------------------------------
+# JavaScript projects (package.json with an npm test script) — vitest, etc.
+# ---------------------------------------------------------------------------
+
+def test_js_script_for_tier():
+    assert js_script_for_tier(None) == "test"  # gated default suite
+    assert js_script_for_tier("unit") == "test:unit"
+    assert js_script_for_tier("e2e") == "test:e2e"
+
+
+def test_discover_js_projects_wants_a_test_script_and_skips_node_modules(tmp_path):
+    app = tmp_path / "stacks/apps/beholder/app"
+    app.mkdir(parents=True)
+    (app / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+    # a package.json with no test script is not a JS test project
+    plain = tmp_path / "stacks/apps/plain/app"
+    plain.mkdir(parents=True)
+    (plain / "package.json").write_text('{"scripts": {"start": "node ."}}')
+    # vendored package.json under node_modules must be ignored
+    nm = app / "node_modules" / "dep"
+    nm.mkdir(parents=True)
+    (nm / "package.json").write_text('{"scripts": {"test": "x"}}')
+    assert discover_js_projects(tmp_path) == ["stacks/apps/beholder/app"]
+
+
+def test_run_js_tests_installs_then_runs_the_default_script(tmp_path):
+    app = tmp_path / "stacks/apps/beholder/app"
+    app.mkdir(parents=True)
+    (app / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+    calls: list = []
+    rc, ran = run_js_tests(tmp_path, ["stacks/apps/beholder/app"], None, runner=_fake_runner(calls))
+    assert rc == 0 and ran is True
+    assert [c[0] for c in calls] == [["npm", "ci"], ["npm", "run", "test"]]
+    assert calls[0][1].endswith("stacks/apps/beholder/app")  # run in the project dir
+
+
+def test_run_js_tests_uses_the_tier_script_when_present(tmp_path):
+    app = tmp_path / "stacks/apps/beholder/app"
+    app.mkdir(parents=True)
+    (app / "package.json").write_text(
+        '{"scripts": {"test": "x", "test:unit": "vitest run tests/unit"}}')
+    calls: list = []
+    run_js_tests(tmp_path, ["stacks/apps/beholder/app"], "unit", runner=_fake_runner(calls))
+    assert ["npm", "run", "test:unit"] in [c[0] for c in calls]
+
+
+def test_run_js_tests_skips_project_without_the_tier_script(tmp_path):
+    app = tmp_path / "stacks/apps/fiber/app"
+    app.mkdir(parents=True)
+    (app / "package.json").write_text('{"scripts": {"test": "vitest run"}}')  # no test:e2e
+    calls: list = []
+    rc, ran = run_js_tests(tmp_path, ["stacks/apps/fiber/app"], "e2e", runner=_fake_runner(calls))
+    assert rc == 0 and ran is False and calls == []
+
+
+def test_run_js_tests_propagates_failure(tmp_path):
+    app = tmp_path / "stacks/apps/beholder/app"
+    app.mkdir(parents=True)
+    (app / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+    rc, ran = run_js_tests(tmp_path, ["stacks/apps/beholder/app"], None,
+                           runner=_fake_runner([], returncode=1))
     assert rc == 1


### PR DESCRIPTION
## What
Makes `ci test` (the Test job from #98) run **JavaScript** test suites too, so an app's browser/JS tests actually gate CI — not just Python.

- **`ci test`**: discovers any dir under `stacks/` whose `package.json` declares a `test` script and runs it (`npm ci` then `npm run test`, or `npm run test:<tier>` for an explicit tier). Skips apps without a script for the tier. An app can be both Python and JS (e.g. fiber) — both run.
- **build.yml**: adds `actions/setup-node` to the Test job so `npm` is available.

## Why
`ci test` was pytest-only, so JS suites (beholder's vitest, fiber's new frontend vitest) ran locally but never in CI. This closes that gap for **all apps**.

## Tests
TDD'd in `tools/ci/tests/test_apptests.py` (discovery, tier→script mapping, npm ci+run ordering, skip-when-no-script, failure propagation, and the `run_tests` ran-any refactor). 35 pass.

Follows #98 (test-job split, now on main).