### PR TITLE
docs: document beholder env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -333,6 +333,23 @@ ACTUAL_PASSWORD=your_actual_budget_password
 ACTUAL_BUDGET_SYNC_ID=your_actual_budget_sync_id
 ACTUAL_BUDGET_ENCRYPTION_PASSWORD=your_actual_budget_encryption_password_if_different
 
+# =============================================================================
+# BEHOLDER BUDGET WATCHDOG
+# =============================================================================
+# Daily budget checks against Actual Budget; alerts via the Postal mail stack.
+# Reuses ACTUAL_PASSWORD / ACTUAL_BUDGET_SYNC_ID above.
+# Postal API credential for sending alert mail (create one in Postal)
+BEHOLDER_POSTAL_API_KEY=your_beholder_postal_api_key
+# Alert recipient(s), comma-separated
+BEHOLDER_ALERT_TO=your_alert_email@example.com
+# Actual account/category names to watch (BEHOLDER_CARD_ACCOUNTS is comma-separated)
+BEHOLDER_CHECKING_ACCOUNT=your_checking_account_name
+BEHOLDER_CARD_ACCOUNTS=your_card_account_names
+BEHOLDER_SAVINGS_CATEGORY=your_savings_category_name
+# Optional — defaults shown
+#BEHOLDER_RUN_AT=07:00
+#BEHOLDER_DRIFT_THRESHOLD_CENTS=20000
+
 EXCALIDRAW_DB_PASSWORD=changeme
 
 # =============================================================================


### PR DESCRIPTION
Beholder (merged in #96) requires several env vars that never got added to `.env.example`, so a fresh setup has no signal to add them — and the deploy fails pre-flight without them.

Adds a **BEHOLDER BUDGET WATCHDOG** section after the Actual Budget block with the 5 required vars (`BEHOLDER_POSTAL_API_KEY`, `BEHOLDER_ALERT_TO`, `BEHOLDER_CHECKING_ACCOUNT`, `BEHOLDER_CARD_ACCOUNTS`, `BEHOLDER_SAVINGS_CATEGORY`) plus the two optional ones (`BEHOLDER_RUN_AT`, `BEHOLDER_DRIFT_THRESHOLD_CENTS`) commented with their defaults. `ACTUAL_PASSWORD`/`ACTUAL_BUDGET_SYNC_ID` are reused from the existing Actual Budget section.

Values in `.env.example` are placeholders only.