### PR TITLE
feat: expose beholder run metrics for prometheus scraping

### DIFF
--- a/stacks/apps/beholder/app/Dockerfile
+++ b/stacks/apps/beholder/app/Dockerfile
@@ -14,4 +14,7 @@ RUN mkdir -p /state && chown node:node /state
 
 USER node
 
+# Prometheus metrics (scraped by the monitoring stack)
+EXPOSE 9090
+
 CMD ["node", "src/index.js"]

--- a/stacks/apps/beholder/app/package-lock.json
+++ b/stacks/apps/beholder/app/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@actual-app/api": "26.5.2"
+        "@actual-app/api": "26.5.2",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@actual-app/sync-server": "26.5.2",
@@ -917,6 +918,15 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.1",
@@ -1926,6 +1936,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -4877,6 +4893,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -5669,6 +5698,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/stacks/apps/beholder/app/package.json
+++ b/stacks/apps/beholder/app/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
-    "@actual-app/api": "26.5.2"
+    "@actual-app/api": "26.5.2",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@actual-app/sync-server": "26.5.2",

--- a/stacks/apps/beholder/app/src/index.js
+++ b/stacks/apps/beholder/app/src/index.js
@@ -3,16 +3,24 @@
 import { loadConfig } from "./config.js";
 import { createLedger } from "./ledger.js";
 import { sendMail } from "./mailer.js";
+import { createMetrics, startMetricsServer } from "./metrics.js";
 import { runOnce } from "./run.js";
 import { loadState, saveState } from "./state.js";
 
 const config = loadConfig();
+const metrics = createMetrics();
 
 async function execute() {
+  const startedAt = Date.now();
   const ledger = createLedger({ ...config.actual, names: config.names });
   const state = await loadState(config.statePath);
   const { findings } = await runOnce({ ledger, config, state });
   await saveState(config.statePath, state);
+  metrics.recordRun({
+    findings,
+    durationSeconds: (Date.now() - startedAt) / 1000,
+    now: Date.now() / 1000,
+  });
   console.log(
     `[beholder] run complete: ${findings.length} finding(s)` +
       (findings.length ? ` -> alerted [${findings.map((f) => f.check).join(", ")}]` : " (quiet)"),
@@ -21,6 +29,7 @@ async function execute() {
 
 // A watchdog must not fail silently: a broken run is itself a finding.
 async function reportFailure(error) {
+  metrics.recordFailure({ now: Date.now() / 1000 });
   console.error("[beholder] run failed:", error.message);
   try {
     await sendMail({
@@ -59,7 +68,9 @@ if (process.env.BEHOLDER_RUN_ONCE === "1") {
       process.exit(1);
     });
 } else {
+  startMetricsServer(metrics.registry);
   console.log(`[beholder] watching; daily run at ${config.runAt} (${process.env.TZ || "UTC"})`);
+  console.log("[beholder] metrics on :9090/metrics");
   const loop = () => {
     setTimeout(async () => {
       try {

--- a/stacks/apps/beholder/app/src/metrics.js
+++ b/stacks/apps/beholder/app/src/metrics.js
@@ -1,0 +1,80 @@
+// Prometheus metrics for the watchdog. In daemon mode a tiny /metrics server runs
+// alongside the scheduler so the monitoring stack can scrape run health — most
+// importantly beholder_last_run_timestamp_seconds, which tells you it's still running
+// even when everything is healthy and no alert email is sent.
+import http from "node:http";
+
+import { Counter, collectDefaultMetrics, Gauge, Registry } from "prom-client";
+
+const CHECKS = ["floor", "raid", "drift", "schedule", "uncategorized"];
+
+export function createMetrics() {
+  const registry = new Registry();
+  collectDefaultMetrics({ register: registry });
+
+  const lastRunTimestamp = new Gauge({
+    name: "beholder_last_run_timestamp_seconds",
+    help: "Unix time of the last completed run (success or failure)",
+    registers: [registry],
+  });
+  const lastRunSuccess = new Gauge({
+    name: "beholder_last_run_success",
+    help: "1 if the last run completed, 0 if it failed",
+    registers: [registry],
+  });
+  const runDuration = new Gauge({
+    name: "beholder_run_duration_seconds",
+    help: "Duration of the last run in seconds",
+    registers: [registry],
+  });
+  const runsTotal = new Counter({
+    name: "beholder_runs_total",
+    help: "Total runs by outcome",
+    labelNames: ["outcome"],
+    registers: [registry],
+  });
+  const findings = new Gauge({
+    name: "beholder_findings",
+    help: "Findings from the last run, by check",
+    labelNames: ["check"],
+    registers: [registry],
+  });
+  // Emit a zero series per check up front, so the metric exists before the first run.
+  for (const check of CHECKS) findings.set({ check }, 0);
+
+  return {
+    registry,
+
+    recordRun({ findings: runFindings, durationSeconds, now }) {
+      lastRunTimestamp.set(now);
+      lastRunSuccess.set(1);
+      runDuration.set(durationSeconds);
+      runsTotal.inc({ outcome: "success" });
+      const counts = Object.fromEntries(CHECKS.map((c) => [c, 0]));
+      for (const f of runFindings) {
+        if (f.check in counts) counts[f.check] += 1;
+      }
+      for (const check of CHECKS) findings.set({ check }, counts[check]);
+    },
+
+    recordFailure({ now }) {
+      lastRunTimestamp.set(now);
+      lastRunSuccess.set(0);
+      runsTotal.inc({ outcome: "failure" });
+    },
+  };
+}
+
+export function startMetricsServer(registry, port = 9090) {
+  const server = http.createServer(async (req, res) => {
+    if (req.method === "GET" && req.url === "/metrics") {
+      res.setHeader("Content-Type", registry.contentType);
+      res.end(await registry.metrics());
+    } else {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  server.listen(port);
+  return server;
+}

--- a/stacks/apps/beholder/app/tests/unit/metrics.test.js
+++ b/stacks/apps/beholder/app/tests/unit/metrics.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { createMetrics, startMetricsServer } from "../../src/metrics.js";
+
+const scrape = (metrics) => metrics.registry.metrics();
+
+describe("createMetrics", () => {
+  it("records a successful run: timestamp, success=1, per-check findings, duration", async () => {
+    const metrics = createMetrics();
+    metrics.recordRun({
+      findings: [{ check: "floor" }, { check: "drift" }, { check: "drift" }],
+      durationSeconds: 2.5,
+      now: 1_700_000_000,
+    });
+
+    const out = await scrape(metrics);
+    expect(out).toContain("beholder_last_run_timestamp_seconds 1700000000");
+    expect(out).toContain("beholder_last_run_success 1");
+    expect(out).toContain("beholder_run_duration_seconds 2.5");
+    expect(out).toContain('beholder_findings{check="drift"} 2');
+    expect(out).toContain('beholder_findings{check="floor"} 1');
+    expect(out).toContain('beholder_findings{check="raid"} 0');
+    expect(out).toContain('beholder_runs_total{outcome="success"} 1');
+  });
+
+  it("records a failed run: timestamp set, success=0, failure counted", async () => {
+    const metrics = createMetrics();
+    metrics.recordFailure({ now: 1_700_000_500 });
+
+    const out = await scrape(metrics);
+    expect(out).toContain("beholder_last_run_timestamp_seconds 1700000500");
+    expect(out).toContain("beholder_last_run_success 0");
+    expect(out).toContain('beholder_runs_total{outcome="failure"} 1');
+  });
+
+  it("initializes all five checks to zero before any run", async () => {
+    const out = await scrape(createMetrics());
+    for (const check of ["floor", "raid", "drift", "schedule", "uncategorized"]) {
+      expect(out).toContain(`beholder_findings{check="${check}"} 0`);
+    }
+  });
+});
+
+describe("startMetricsServer", () => {
+  it("serves the registry over http on GET /metrics", async () => {
+    const metrics = createMetrics();
+    metrics.recordRun({ findings: [], durationSeconds: 1, now: 1_700_000_000 });
+    const server = startMetricsServer(metrics.registry, 0); // ephemeral port
+    try {
+      await new Promise((resolve) => server.once("listening", resolve));
+      const { port } = server.address();
+      const res = await fetch(`http://127.0.0.1:${port}/metrics`);
+      const body = await res.text();
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/plain");
+      expect(body).toContain("beholder_last_run_success 1");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("404s on any other path", async () => {
+    const server = startMetricsServer(createMetrics().registry, 0);
+    try {
+      await new Promise((resolve) => server.once("listening", resolve));
+      const { port } = server.address();
+      const res = await fetch(`http://127.0.0.1:${port}/nope`);
+      expect(res.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/stacks/apps/beholder/docker-compose.yml
+++ b/stacks/apps/beholder/docker-compose.yml
@@ -37,6 +37,11 @@ services:
                 condition: any
                 delay: 30s
             labels:
+                # Prometheus (swarm-tasks SD scrapes beholder:9090/metrics internally)
+                - "prometheus.scrape=true"
+                - "prometheus.port=beholder:9090"
+                - "prometheus.path=/metrics"
+                # Homepage
                 - homepage.group=Finance
                 - homepage.name=Beholder
                 - homepage.icon=mdi-eye-outline


### PR DESCRIPTION
## What
Gives beholder a Prometheus `/metrics` endpoint (mirroring warden) so the monitoring stack can see it's running — the fix for its silent-when-healthy blind spot.

- **`src/metrics.js`** (`prom-client`): `beholder_last_run_timestamp_seconds` (the liveness signal), `beholder_last_run_success` (0/1), `beholder_findings{check=...}`, `beholder_run_duration_seconds`, `beholder_runs_total{outcome}`, + default process metrics.
- **Daemon mode** starts a tiny HTTP server on `:9090/metrics`, updated after every run; one-shot `RUN_ONCE` stays a pure one-shot.
- **Compose**: `prometheus.scrape=true` / `prometheus.port=beholder:9090` / `prometheus.path=/metrics` (beholder is already on `traefik-public`, the scrape network). Dockerfile `EXPOSE 9090`.

## Tests
TDD'd with vitest — metrics reflect findings/success/timestamp after success and failure, and the `/metrics` server serves valid Prometheus text (5 new tests; full suite 49 pass). biome clean.

## Follow-up (separate PR, as agreed)
The stale-run alert rule (`beholder_last_run_timestamp_seconds` older than ~25h) in `monitoring/alert-rules.yml` — needs the config-version bump + monitoring redeploy.