### PR TITLE
Beholder watchdog hardening + monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -350,6 +350,19 @@ BEHOLDER_SAVINGS_CATEGORY=your_savings_category_name
 #BEHOLDER_RUN_AT=07:00
 #BEHOLDER_DRIFT_THRESHOLD_CENTS=20000
 
+# =============================================================================
+# ALERTMANAGER (Prometheus alert email routing)
+# =============================================================================
+# Routes firing Prometheus alerts to email via the Postal mail stack:
+#   alertmanager -> postal_smtp:2525 -> relay -> smtp2go -> inbox
+# Mint an SMTP-type credential on the Postal mail server (Postal UI ->
+# Credentials -> SMTP) and paste its username/password here. Avoid '|' and '&'
+# in the password (the config template is rendered with sed).
+ALERTMANAGER_SMTP_USERNAME=your_postal_smtp_username
+ALERTMANAGER_SMTP_PASSWORD=your_postal_smtp_password
+# Where alerts are delivered (comma-separated for multiple)
+ALERTMANAGER_ALERT_TO=chutchens@diyhub.dev
+
 EXCALIDRAW_DB_PASSWORD=changeme
 
 # =============================================================================

--- a/stacks/apps/beholder/app/src/index.js
+++ b/stacks/apps/beholder/app/src/index.js
@@ -4,15 +4,19 @@ import { loadConfig } from "./config.js";
 import { createLedger } from "./ledger.js";
 import { sendMail } from "./mailer.js";
 import { createMetrics, startMetricsServer } from "./metrics.js";
+import { createReporter } from "./reporter.js";
 import { runOnce } from "./run.js";
 import { loadState, saveState } from "./state.js";
+import { createSupervisor } from "./supervisor.js";
 
 const config = loadConfig();
 const metrics = createMetrics();
+const reportFailure = createReporter({ metrics, sendMail, config });
+const supervisor = createSupervisor({ proc: process, onFatal: reportFailure, log: console.warn });
 
 async function execute() {
   const startedAt = Date.now();
-  const ledger = createLedger({ ...config.actual, names: config.names });
+  const ledger = createLedger({ ...config.actual, names: config.names, bestEffort: supervisor.bestEffort });
   const state = await loadState(config.statePath);
   const { findings } = await runOnce({ ledger, config, state });
   await saveState(config.statePath, state);
@@ -25,24 +29,6 @@ async function execute() {
     `[beholder] run complete: ${findings.length} finding(s)` +
       (findings.length ? ` -> alerted [${findings.map((f) => f.check).join(", ")}]` : " (quiet)"),
   );
-}
-
-// A watchdog must not fail silently: a broken run is itself a finding.
-async function reportFailure(error) {
-  metrics.recordFailure({ now: Date.now() / 1000 });
-  console.error("[beholder] run failed:", error.message);
-  try {
-    await sendMail({
-      postalUrl: config.postalUrl,
-      postalApiKey: config.postalApiKey,
-      from: config.alertFrom,
-      to: config.alertTo,
-      subject: "beholder: run failed - the watchdog itself needs attention",
-      body: `beholder could not complete its checks:\n\n${error.message}\n\nUntil this is fixed, nothing is being watched.`,
-    });
-  } catch (mailError) {
-    console.error("[beholder] failure email also failed:", mailError.message);
-  }
 }
 
 function msUntilNextRun(runAt, now = new Date()) {

--- a/stacks/apps/beholder/app/src/ledger.js
+++ b/stacks/apps/beholder/app/src/ledger.js
@@ -24,7 +24,7 @@ function resolveByName(kind, list, name) {
   return hit;
 }
 
-export function createLedger({ serverUrl, password, syncId, dataDir, names }) {
+export function createLedger({ serverUrl, password, syncId, dataDir, names, bestEffort = (fn) => fn() }) {
   let checkingId;
   let cardIds; // [{id, name}]
   let savingsCategoryId;
@@ -41,13 +41,17 @@ export function createLedger({ serverUrl, password, syncId, dataDir, names }) {
       const categories = await api.getCategories();
       savingsCategoryId = resolveByName("category", categories, names.savingsCategory).id;
 
-      // Pull fresh bank data before checking; stale checks beat no checks,
-      // so a sync failure only warns.
-      try {
-        await api.runBankSync();
-      } catch (e) {
-        console.warn(`[beholder] bank sync failed (continuing with last-synced data): ${e.message}`);
-      }
+      // Pull fresh bank data before checking; stale checks beat no checks. A
+      // sync failure only warns — including the out-of-band rejections the
+      // Actual API throws for a bank link in trouble, which bestEffort keeps
+      // from crashing the run.
+      await bestEffort(async () => {
+        try {
+          await api.runBankSync();
+        } catch (e) {
+          console.warn(`[beholder] bank sync failed (continuing with last-synced data): ${e.message}`);
+        }
+      });
     },
 
     async close() {

--- a/stacks/apps/beholder/app/src/reporter.js
+++ b/stacks/apps/beholder/app/src/reporter.js
@@ -1,0 +1,19 @@
+// A watchdog must not fail silently: a broken run is itself a finding.
+export function createReporter({ metrics, sendMail, config, log = console.error }) {
+  return async function reportFailure(error) {
+    metrics.recordFailure({ now: Date.now() / 1000 });
+    log(`[beholder] run failed: ${error.stack || error.message}`);
+    try {
+      await sendMail({
+        postalUrl: config.postalUrl,
+        postalApiKey: config.postalApiKey,
+        from: config.alertFrom,
+        to: config.alertTo,
+        subject: "beholder: run failed - the watchdog itself needs attention",
+        body: `beholder could not complete its checks:\n\n${error.message}\n\nUntil this is fixed, nothing is being watched.`,
+      });
+    } catch (mailError) {
+      log(`[beholder] failure email also failed: ${mailError.message}`);
+    }
+  };
+}

--- a/stacks/apps/beholder/app/src/supervisor.js
+++ b/stacks/apps/beholder/app/src/supervisor.js
@@ -1,0 +1,43 @@
+// Owns the process-level safety net. Errors that escape the awaited run (e.g. a
+// background bank-sync promise the Actual API rejects out of band) would crash
+// the process before reportFailure runs — the watchdog dying silently. Fatal
+// errors are reported then exit nonzero; errors raised inside bestEffort() are
+// tolerated so a flaky bank sync degrades to "check on last-synced data".
+export function createSupervisor({ proc, onFatal, log = () => {}, exit = (code) => proc.exit(code) }) {
+  let suppressed = 0;
+  let handled = false;
+
+  const handle = async (error) => {
+    if (suppressed > 0) {
+      log(`[beholder] ignored async error during best-effort work: ${error.message}`);
+      return;
+    }
+    if (handled) return;
+    handled = true;
+    try {
+      await onFatal(error);
+    } catch {
+      // reporter failed too — exit anyway
+    }
+    exit(1);
+  };
+
+  proc.on("unhandledRejection", handle);
+  proc.on("uncaughtException", handle);
+
+  return {
+    async bestEffort(fn) {
+      suppressed++;
+      try {
+        return await fn();
+      } finally {
+        await new Promise((r) => setImmediate(r)); // let background rejections surface while still suppressed
+        suppressed--;
+      }
+    },
+    dispose() {
+      proc.removeListener("unhandledRejection", handle);
+      proc.removeListener("uncaughtException", handle);
+    },
+  };
+}

--- a/stacks/apps/beholder/app/tests/integration/fixtures/supervisor-harness.mjs
+++ b/stacks/apps/beholder/app/tests/integration/fixtures/supervisor-harness.mjs
@@ -1,0 +1,33 @@
+// Exercises the real supervisor + reporter in a real Node process. MODE=fatal
+// raises an out-of-band rejection outside best-effort work (must email + exit 1);
+// MODE=suppressed raises one inside best-effort work (must be tolerated, run continues).
+import { createReporter } from "../../../src/reporter.js";
+import { createSupervisor } from "../../../src/supervisor.js";
+
+const config = {
+  postalUrl: process.env.POSTAL_URL,
+  postalApiKey: "harness-key",
+  alertFrom: "budget@harness.test",
+  alertTo: ["to@harness.test"],
+};
+
+const sendMail = async (msg) => {
+  await fetch(`${config.postalUrl}/api/v1/send/message`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-server-api-key": config.postalApiKey },
+    body: JSON.stringify(msg),
+  });
+};
+
+const reportFailure = createReporter({ metrics: { recordFailure() {} }, sendMail, config, log() {} });
+const supervisor = createSupervisor({ proc: process, onFatal: reportFailure, log() {} });
+
+if (process.env.MODE === "fatal") {
+  Promise.reject(new Error("out-of-band fatal"));
+} else {
+  await supervisor.bestEffort(async () => {
+    Promise.reject(new Error("bank sync noise"));
+  });
+  console.log("run continued");
+  process.exit(0);
+}

--- a/stacks/apps/beholder/app/tests/integration/supervisor.e2e.test.js
+++ b/stacks/apps/beholder/app/tests/integration/supervisor.e2e.test.js
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+import * as mockttp from "mockttp";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// The supervisor runs in a REAL child process against mockttp standing in for
+// Postal. Observed only through real surfaces: child exit code and captured
+// failure emails. No src/ import here — the child does that.
+
+const HARNESS = resolve(import.meta.dirname, "fixtures/supervisor-harness.mjs");
+const postal = mockttp.getLocal();
+let sendEndpoint;
+
+beforeAll(async () => {
+  await postal.start();
+  sendEndpoint = await postal
+    .forPost("/api/v1/send/message")
+    .thenJson(200, { status: "success", data: { message_id: "e2e" } });
+});
+
+afterAll(async () => {
+  await postal.stop();
+});
+
+function runHarness(mode) {
+  return new Promise((res) => {
+    const proc = spawn("node", [HARNESS], {
+      env: { ...process.env, MODE: mode, POSTAL_URL: `http://127.0.0.1:${postal.port}` },
+    });
+    let stdout = "";
+    proc.stdout.on("data", (d) => (stdout += d));
+    proc.on("exit", (code) => res({ code, stdout }));
+  });
+}
+
+describe("supervisor in a real process", () => {
+  it("emails the failure and exits nonzero when a rejection escapes the run", async () => {
+    const before = (await sendEndpoint.getSeenRequests()).length;
+
+    const run = await runHarness("fatal");
+
+    expect(run.code).toBe(1);
+    const requests = (await sendEndpoint.getSeenRequests()).slice(before);
+    expect(requests.length).toBe(1);
+    const msg = await requests[0].body.getJson();
+    expect(msg.subject).toMatch(/beholder.*(failed|attention)/i);
+    expect(msg.body).toContain("out-of-band fatal");
+  }, 20000);
+
+  it("tolerates a rejection raised during best-effort work and completes", async () => {
+    const before = (await sendEndpoint.getSeenRequests()).length;
+
+    const run = await runHarness("suppressed");
+
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain("run continued");
+    expect((await sendEndpoint.getSeenRequests()).slice(before).length).toBe(0);
+  }, 20000);
+});

--- a/stacks/apps/beholder/app/tests/unit/reporter.test.js
+++ b/stacks/apps/beholder/app/tests/unit/reporter.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createReporter } from "../../src/reporter.js";
+
+const config = {
+  postalUrl: "http://postal.unit.test",
+  postalApiKey: "unit-key",
+  alertFrom: "budget@unit.test",
+  alertTo: ["a@unit.test", "b@unit.test"],
+};
+
+function setup({ sendMail } = {}) {
+  const metrics = { recordFailure: vi.fn() };
+  const mailer = sendMail ?? vi.fn().mockResolvedValue({ message_id: "unit" });
+  const log = vi.fn();
+  const reportFailure = createReporter({ metrics, sendMail: mailer, config, log });
+  return { reportFailure, metrics, mailer, log };
+}
+
+describe("createReporter", () => {
+  it("records the failure metric and emails the alert", async () => {
+    const { reportFailure, metrics, mailer } = setup();
+
+    await reportFailure(new Error("names no longer resolve"));
+
+    expect(metrics.recordFailure).toHaveBeenCalledTimes(1);
+    expect(metrics.recordFailure.mock.calls[0][0]).toHaveProperty("now", expect.any(Number));
+    expect(mailer).toHaveBeenCalledTimes(1);
+    const msg = mailer.mock.calls[0][0];
+    expect(msg.to).toEqual(["a@unit.test", "b@unit.test"]);
+    expect(msg.from).toBe("budget@unit.test");
+    expect(msg.subject).toMatch(/beholder.*(failed|attention)/i);
+    expect(msg.body).toContain("names no longer resolve");
+  });
+
+  it("logs the full stack, not just the message", async () => {
+    const { reportFailure, log } = setup();
+    const error = new Error("boom");
+
+    await reportFailure(error);
+
+    const logged = log.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toContain(error.stack);
+  });
+
+  it("does not throw when the failure email itself fails", async () => {
+    const sendMail = vi.fn().mockRejectedValue(new Error("postal down"));
+    const { reportFailure, log } = setup({ sendMail });
+
+    await expect(reportFailure(new Error("original"))).resolves.toBeUndefined();
+    const logged = log.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toContain("postal down");
+  });
+});

--- a/stacks/apps/beholder/app/tests/unit/supervisor.test.js
+++ b/stacks/apps/beholder/app/tests/unit/supervisor.test.js
@@ -1,0 +1,131 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createSupervisor } from "../../src/supervisor.js";
+
+// `proc` and `exit` are injected seams so tests drive a real emitter and a spied
+// exit instead of mutating the global process.
+function setup({ onFatal } = {}) {
+  const proc = new EventEmitter();
+  const exit = vi.fn();
+  const log = vi.fn();
+  const reporter = onFatal ?? vi.fn().mockResolvedValue(undefined);
+  const supervisor = createSupervisor({ proc, onFatal: reporter, exit, log });
+  return { proc, exit, log, onFatal: reporter, supervisor };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("createSupervisor — fatal handling", () => {
+  it("reports and exits nonzero on an unhandled rejection outside best-effort work", async () => {
+    const { proc, exit, onFatal } = setup();
+    const error = new Error("real fatal");
+
+    proc.emit("unhandledRejection", error);
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledWith(error);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports and exits nonzero on an uncaught exception", async () => {
+    const { proc, exit, onFatal } = setup();
+    const error = new Error("splat");
+
+    proc.emit("uncaughtException", error);
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledWith(error);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit until the reporter has finished (email before exit)", async () => {
+    let release;
+    const onFatal = vi.fn(() => new Promise((r) => (release = r)));
+    const { proc, exit } = setup({ onFatal });
+
+    proc.emit("unhandledRejection", new Error("boom"));
+    await flush();
+    expect(onFatal).toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+
+    release();
+    await flush();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("still exits nonzero when the reporter itself fails", async () => {
+    const onFatal = vi.fn().mockRejectedValue(new Error("postal down too"));
+    const { proc, exit } = setup({ onFatal });
+
+    proc.emit("unhandledRejection", new Error("boom"));
+    await flush();
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports and exits only once when several fatal events fire", async () => {
+    const { proc, exit, onFatal } = setup();
+
+    proc.emit("unhandledRejection", new Error("first"));
+    proc.emit("uncaughtException", new Error("second"));
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createSupervisor — best-effort suppression", () => {
+  it("suppresses (does not treat as fatal) a rejection raised during best-effort work", async () => {
+    const { proc, exit, onFatal, log, supervisor } = setup();
+
+    await supervisor.bestEffort(async () => {
+      proc.emit("unhandledRejection", new Error("bank sync noise"));
+    });
+    await flush();
+
+    expect(onFatal).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+    const logged = log.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toContain("bank sync noise");
+  });
+
+  it("suppresses a background rejection that surfaces just after the work resolves", async () => {
+    const { proc, exit, onFatal, supervisor } = setup();
+
+    await supervisor.bestEffort(async () => {
+      setImmediate(() => proc.emit("unhandledRejection", new Error("out-of-band")));
+    });
+    await flush();
+
+    expect(onFatal).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("returns the wrapped function's value and resumes treating rejections as fatal afterward", async () => {
+    const { proc, exit, onFatal, supervisor } = setup();
+
+    const value = await supervisor.bestEffort(async () => 42);
+    expect(value).toBe(42);
+
+    proc.emit("unhandledRejection", new Error("after the window"));
+    await flush();
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("createSupervisor — dispose", () => {
+  it("removes its process listeners", () => {
+    const { proc, supervisor } = setup();
+    expect(proc.listenerCount("unhandledRejection")).toBe(1);
+    expect(proc.listenerCount("uncaughtException")).toBe(1);
+
+    supervisor.dispose();
+
+    expect(proc.listenerCount("unhandledRejection")).toBe(0);
+    expect(proc.listenerCount("uncaughtException")).toBe(0);
+  });
+});

--- a/stacks/apps/postal/docker-compose.yml
+++ b/stacks/apps/postal/docker-compose.yml
@@ -115,7 +115,11 @@ services:
     depends_on:
       - db
     networks:
+      # traefik-public lets cross-stack senders that only speak SMTP (e.g.
+      # monitoring's Alertmanager) reach postal_smtp:2525. No published port /
+      # traefik router — reachable on the overlay only, and AUTH-gated.
       - postal-internal
+      - traefik-public
     deploy:
       placement:
         constraints:

--- a/stacks/monitoring/alert-rules.yml
+++ b/stacks/monitoring/alert-rules.yml
@@ -67,3 +67,28 @@ groups:
         annotations:
           summary: "Fiber: {{ $labels.db }} dump failed (clogged)"
           description: "A dump for {{ $labels.db }} failed in the last hour — pull the stool sample in the drawer."
+
+  # Beholder: the budget watchdog is quiet by default, so absence of email is
+  # not proof of life — alert if it stops running or its own run breaks.
+  - name: beholder
+    interval: 30s
+    rules:
+      - alert: BeholderStale
+        expr: time() - beholder_last_run_timestamp_seconds > 90000
+        for: 10m
+        labels:
+          severity: warning
+          component: beholder
+        annotations:
+          summary: "Beholder has not run in over 25h"
+          description: "Last completed run was {{ $value | humanizeDuration }} ago (daily run expected every ~24h). The watchdog may be down — nothing is watching the budget. Check logs: docker service logs $(docker service ls -qf name=beholder)"
+
+      - alert: BeholderRunFailed
+        expr: beholder_last_run_success == 0
+        for: 5m
+        labels:
+          severity: critical
+          component: beholder
+        annotations:
+          summary: "Beholder's last run failed — the watchdog itself needs attention"
+          description: "The most recent run did not complete, so the budget checks did not run. Beholder also emails a 'run failed' alert; investigate the Actual sync and beholder logs."

--- a/stacks/monitoring/alertmanager.yml
+++ b/stacks/monitoring/alertmanager.yml
@@ -1,0 +1,33 @@
+# Alertmanager routing config — TEMPLATE.
+# Placeholders (…_PLACEHOLDER) are substituted at container start from env vars
+# (see the alertmanager service `command` in docker-compose.yml), because Swarm
+# configs are static and Alertmanager does not expand env vars in YAML itself.
+#
+# Delivery path mirrors the house mail platform:
+#   alertmanager -> postal_smtp:2525 (SMTP AUTH) -> relay -> smtp2go -> inbox
+# SMTP creds come from a Postal SMTP-type credential (mint one in the Postal UI).
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: 'postal_smtp:2525'
+  smtp_from: 'alerts@BASE_DOMAIN_PLACEHOLDER'
+  smtp_auth_username: 'SMTP_USERNAME_PLACEHOLDER'
+  smtp_auth_password: 'SMTP_PASSWORD_PLACEHOLDER'
+  # Postal SMTP on the internal overlay; skip STARTTLS (no cert for the internal
+  # hostname). Flip to true if Postal is configured to require TLS on intake.
+  smtp_require_tls: false
+
+route:
+  receiver: house-email
+  # Collapse a storm of the same alert into one mail; keep components separate.
+  group_by: ['alertname', 'component']
+  group_wait: 30s
+  group_interval: 5m
+  # Re-send a still-firing alert at most this often (beholder is daily, so a
+  # tight repeat would just be noise).
+  repeat_interval: 6h
+
+receivers:
+  - name: house-email
+    email_configs:
+      - to: 'ALERT_TO_PLACEHOLDER'
+        send_resolved: true

--- a/stacks/monitoring/dashboards/local/beholder.json
+++ b/stacks/monitoring/dashboards/local/beholder.json
@@ -1,0 +1,834 @@
+{
+ "annotations": {
+  "list": [
+   {
+    "builtIn": 1,
+    "datasource": {
+     "type": "grafana",
+     "uid": "-- Grafana --"
+    },
+    "enable": true,
+    "hide": true,
+    "iconColor": "rgba(0, 211, 255, 1)",
+    "name": "Annotations & Alerts",
+    "type": "dashboard"
+   }
+  ]
+ },
+ "editable": true,
+ "fiscalYearStartMonth": 0,
+ "graphTooltip": 1,
+ "id": null,
+ "links": [],
+ "liveNow": false,
+ "panels": [
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Did the last daily run complete? beholder is quiet by default — no alert email does NOT prove it ran, so this is the primary liveness signal. Healthy = the run finished (checks may or may not have found anything); Failed = the watchdog itself broke and nothing is being watched.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [
+      {
+       "options": {
+        "0": {
+         "color": "red",
+         "index": 1,
+         "text": "Failed"
+        },
+        "1": {
+         "color": "green",
+         "index": 0,
+         "text": "Healthy"
+        }
+       },
+       "type": "value"
+      }
+     ],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 0,
+    "y": 0
+   },
+   "id": 1,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "orientation": "auto",
+    "percentChangeColorMode": "standard",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "showPercentChange": false,
+    "textMode": "auto",
+    "wideLayout": true
+   },
+   "pluginVersion": "11.1.4",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "beholder_last_run_success",
+     "legendFormat": "last run",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Last run status",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Time since the last run completed. beholder runs once a day, so this normally sawtooths up to ~24h and resets. Green < 25h (on schedule); yellow > 25h (missed a day — investigate); red > 48h (dead, no runs for two days).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 90000
+       },
+       {
+        "color": "red",
+        "value": 172800
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 6,
+    "y": 0
+   },
+   "id": 2,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "orientation": "auto",
+    "percentChangeColorMode": "standard",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "showPercentChange": false,
+    "textMode": "auto",
+    "wideLayout": true
+   },
+   "pluginVersion": "11.1.4",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "time() - beholder_last_run_timestamp_seconds",
+     "legendFormat": "age",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Last run age",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "How long the last run took end to end (bank sync + four checks). A sudden jump usually means the Actual sync is slow or hanging.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "blue",
+        "value": null
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 12,
+    "y": 0
+   },
+   "id": 3,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "orientation": "auto",
+    "percentChangeColorMode": "standard",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "showPercentChange": false,
+    "textMode": "auto",
+    "wideLayout": true
+   },
+   "pluginVersion": "11.1.4",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "beholder_run_duration_seconds",
+     "legendFormat": "duration",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Last run duration",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Total findings across all four checks from the last run. 0 = the household budget is in good shape (the quiet, healthy state). Anything above 0 means beholder emailed an alert — use the breakdown below to see which check fired.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 18,
+    "y": 0
+   },
+   "id": 4,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "orientation": "auto",
+    "percentChangeColorMode": "standard",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "showPercentChange": false,
+    "textMode": "auto",
+    "wideLayout": true
+   },
+   "pluginVersion": "11.1.4",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "sum(beholder_findings)",
+     "legendFormat": "open findings",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Open findings (last run)",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Findings from the last run, broken out by check. floor = checking below card debt; raid = money left savings; drift = a card's debt jumped > threshold vs ~30 days ago; schedule = a scheduled payee posted the wrong amount; uncategorized = on-budget transactions with no category. Green = clear.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 24,
+    "x": 0,
+    "y": 4
+   },
+   "id": 5,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "orientation": "horizontal",
+    "percentChangeColorMode": "standard",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "showPercentChange": false,
+    "textMode": "value_and_name",
+    "wideLayout": true
+   },
+   "pluginVersion": "11.1.4",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "beholder_findings",
+     "legendFormat": "{{check}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Findings by check (last run)",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Findings per check over time. Condition findings (floor, drift) persist day after day until resolved — a flat line above 0 is a standing problem. Event findings (raid, schedule, uncategorized) spike on the day they occur and clear once handled.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 15,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "stepAfter",
+      "lineWidth": 2,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": true,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "min": 0,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 9
+   },
+   "id": 6,
+   "options": {
+    "legend": {
+     "calcs": [
+      "last",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "beholder_findings",
+     "legendFormat": "{{check}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Findings by check over time",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Completed runs per day by outcome. Under normal operation this is one success bar per day. Any failure bar means beholder crashed a run (it also emails a 'run failed' alert); a day with no bar at all means it never ran.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "bars",
+      "fillOpacity": 70,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "never",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "normal"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "min": 0,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byName",
+       "options": "failure"
+      },
+      "properties": [
+       {
+        "id": "color",
+        "value": {
+         "fixedColor": "red",
+         "mode": "fixed"
+        }
+       }
+      ]
+     },
+     {
+      "matcher": {
+       "id": "byName",
+       "options": "success"
+      },
+      "properties": [
+       {
+        "id": "color",
+        "value": {
+         "fixedColor": "green",
+         "mode": "fixed"
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 9
+   },
+   "id": 7,
+   "options": {
+    "legend": {
+     "calcs": [
+      "sum"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "sum by (outcome) (increase(beholder_runs_total[24h]))",
+     "legendFormat": "{{outcome}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Runs per day by outcome",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Age of the last completed run over time. Healthy operation is a sawtooth that resets to ~0 each day. A line that keeps climbing without resetting is the clearest sign the watchdog has stopped running.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 2,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "never",
+      "spanNulls": true,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "dashed"
+      }
+     },
+     "mappings": [],
+     "min": 0,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 90000
+       },
+       {
+        "color": "red",
+        "value": 172800
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 17
+   },
+   "id": 8,
+   "options": {
+    "legend": {
+     "calcs": [
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "time() - beholder_last_run_timestamp_seconds",
+     "legendFormat": "run age",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Run staleness over time",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "description": "Duration of each run over time. Trending up points at a slow or hanging bank sync (each run triggers an Actual sync first). A gap here also indicates missed runs.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 2,
+      "pointSize": 6,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": true,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "min": 0,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 17
+   },
+   "id": 9,
+   "options": {
+    "legend": {
+     "calcs": [
+      "last",
+      "max",
+      "mean"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "editorMode": "code",
+     "expr": "beholder_run_duration_seconds",
+     "legendFormat": "duration",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Run duration over time",
+   "type": "timeseries"
+  }
+ ],
+ "refresh": "5m",
+ "schemaVersion": 39,
+ "tags": [
+  "beholder",
+  "finance",
+  "watchdog"
+ ],
+ "templating": {
+  "list": []
+ },
+ "time": {
+  "from": "now-7d",
+  "to": "now"
+ },
+ "timepicker": {},
+ "timezone": "",
+ "title": "Beholder — Budget Watchdog",
+ "uid": "beholder-budget-watchdog",
+ "version": 1,
+ "weekStart": ""
+}

--- a/stacks/monitoring/docker-compose.yml
+++ b/stacks/monitoring/docker-compose.yml
@@ -10,9 +10,9 @@ services:
             - prometheus_data:/prometheus
             - /var/run/docker.sock:/var/run/docker.sock:ro
         configs:
-            - source: prometheus_config_v8
+            - source: prometheus_config_v9
               target: /etc/prometheus/prometheus.yml
-            - source: prometheus_alert_rules_v1
+            - source: prometheus_alert_rules_v2
               target: /etc/prometheus/alert-rules.yml
             - source: minio_targets
               target: /etc/prometheus/targets/minio-targets.json
@@ -37,6 +37,58 @@ services:
                 - homepage.icon=prometheus.png
                 - homepage.href=https://prometheus.${BASE_DOMAIN}/
                 - homepage.description=Metrics Collection
+
+    alertmanager:
+        image: prom/alertmanager:v0.27.0
+        # Swarm configs are static; render the template from env at start, then exec.
+        # sed uses '|' as delimiter — Postal SMTP creds must not contain '|' or '&'.
+        command:
+            - sh
+            - -c
+            - >
+                sed -e "s|BASE_DOMAIN_PLACEHOLDER|$${BASE_DOMAIN}|g"
+                -e "s|SMTP_USERNAME_PLACEHOLDER|$${ALERTMANAGER_SMTP_USERNAME}|g"
+                -e "s|SMTP_PASSWORD_PLACEHOLDER|$${ALERTMANAGER_SMTP_PASSWORD}|g"
+                -e "s|ALERT_TO_PLACEHOLDER|$${ALERTMANAGER_ALERT_TO}|g"
+                /etc/alertmanager/alertmanager.tmpl.yml > /tmp/alertmanager.yml
+                && exec /bin/alertmanager
+                --config.file=/tmp/alertmanager.yml
+                --storage.path=/alertmanager
+                --web.external-url=https://alertmanager.$${BASE_DOMAIN}
+        environment:
+            - BASE_DOMAIN=${BASE_DOMAIN}
+            - ALERTMANAGER_SMTP_USERNAME=${ALERTMANAGER_SMTP_USERNAME}
+            - ALERTMANAGER_SMTP_PASSWORD=${ALERTMANAGER_SMTP_PASSWORD}
+            - ALERTMANAGER_ALERT_TO=${ALERTMANAGER_ALERT_TO}
+        networks:
+            - traefik-public
+        volumes:
+            - alertmanager_data:/alertmanager
+        configs:
+            - source: alertmanager_config_v1
+              target: /etc/alertmanager/alertmanager.tmpl.yml
+        deploy:
+            # dnsrr for the same broken-VIP reason as prometheus/loki below;
+            # prometheus reaches this by service name over dnsrr.
+            endpoint_mode: dnsrr
+            placement:
+                constraints:
+                    - node.role == manager
+            labels:
+                - "traefik.enable=true"
+                - "traefik.http.routers.alertmanager.rule=Host(`alertmanager.${BASE_DOMAIN}`)"
+                - "traefik.http.routers.alertmanager.entrypoints=websecure"
+                - "traefik.http.routers.alertmanager.tls.certresolver=dns"
+                - "traefik.http.services.alertmanager.loadbalancer.server.port=9093"
+                - "traefik.swarm.network=traefik-public"
+                - homepage.group=Monitoring
+                - homepage.name=Alertmanager
+                - homepage.icon=mdi-bell-alert
+                - homepage.href=https://alertmanager.${BASE_DOMAIN}/
+                - homepage.description=Alert Routing
+            restart_policy:
+                condition: any
+                delay: 5s
 
     grafana:
         image: grafana/grafana:11.1.4
@@ -63,6 +115,8 @@ services:
               target: /etc/grafana/provisioning/dashboards-local/node-resources.json
             - source: dashboard_warden_v7
               target: /etc/grafana/provisioning/dashboards-local/warden.json
+            - source: dashboard_beholder_v1
+              target: /etc/grafana/provisioning/dashboards-local/beholder.json
         environment:
             - GF_SECURITY_ADMIN_USER=admin
             - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
@@ -269,6 +323,7 @@ networks:
 
 volumes:
     prometheus_data:
+    alertmanager_data:
     grafana_data:
     loki_data:
     promtail_positions:
@@ -280,10 +335,12 @@ volumes:
             device: "//${NAS_SERVER}/grafana_dashboards"
 
 configs:
-    prometheus_config_v8:
+    prometheus_config_v9:
         file: ./prometheus.yml
-    prometheus_alert_rules_v1:
+    prometheus_alert_rules_v2:
         file: ./alert-rules.yml
+    alertmanager_config_v1:
+        file: ./alertmanager.yml
     minio_targets:
         file: ./minio-targets.json
     grafana_dashboards_provisioning:
@@ -298,6 +355,8 @@ configs:
         file: ./dashboards/local/node-resources.json
     dashboard_warden_v7:
         file: ./dashboards/local/warden.json
+    dashboard_beholder_v1:
+        file: ./dashboards/local/beholder.json
     prometheus_datasource:
         file: ./datasources/prometheus.yml
     loki_datasource:

--- a/stacks/monitoring/prometheus.yml
+++ b/stacks/monitoring/prometheus.yml
@@ -5,6 +5,11 @@ global:
 rule_files:
   - /etc/prometheus/alert-rules.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   # Prometheus itself
   - job_name: "prometheus"


### PR DESCRIPTION
## Why
While checking whether beholder was running, found it had been **down for days** (deploy pinned a nonexistent image tag) and, once up, **crashed silently on every run**: the Actual API throws an out-of-band rejection for a bank link in `ACCOUNT_NEEDS_ATTENTION`, escaping beholder's try/catch and killing the process before `reportFailure` could email — the watchdog failing silently.

## What
**`fix:` beholder resilience**
- `supervisor.js` — process-level safety net: errors escaping the awaited run are reported then exit nonzero; errors inside a `bestEffort()` window (the bank sync) are tolerated so a flaky link degrades to "check on last-synced data" instead of aborting.
- `reporter.js` — extracted, testable failure reporter; now logs the full stack.
- `ledger.js` / `index.js` — sync runs through `bestEffort`; thin composition.
- Tests: reporter (3) + supervisor (9) unit, plus a real-process integration test proving fatal→email+exit and best-effort→continue. 63 pass, lint clean.

**`feat:` monitoring**
- Grafana dashboard for beholder run health (staleness is the key liveness signal).
- Prometheus alert rules: `BeholderStale` (>25h) and `BeholderRunFailed`.
- Alertmanager wired to email via Postal SMTP. **Requires `ALERTMANAGER_SMTP_*` env + a Postal SMTP credential before the monitoring stack is redeployed** — see `.env.example`.

## Follow-up
- Re-auth the "Cody - DIRECT SUB AA." account in Actual (root operational cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)