### PR TITLE
fix: beholder reaches Postal via the traefik hostname

### DIFF
--- a/stacks/apps/beholder/README.md
+++ b/stacks/apps/beholder/README.md
@@ -1,7 +1,7 @@
 # beholder
 
 Budget watchdog. Once a day it reads the household budget from the Actual
-server and runs four checks; if anything is wrong it sends one email through
+server and runs five checks; if anything is wrong it sends one email through
 Postal (`budget@${BASE_DOMAIN}`) to everyone in `BEHOLDER_ALERT_TO`.
 **Quiet by default — no email means all checks passed.**
 
@@ -46,6 +46,21 @@ docker exec -e BEHOLDER_RUN_ONCE=1 $(docker ps -qf name=beholder) node src/index
 
 Exit 0 and a `run complete` log line = the full pipeline works. It prints
 `(quiet)` when there is nothing to report.
+
+## Postal integration
+
+Alert mail goes through Postal's HTTP API at `https://postal.${BASE_DOMAIN}`
+(`BEHOLDER_POSTAL_URL` in `docker-compose.yml`). It must be the traefik
+hostname, **not** the internal `postal_web:5000` service address: Postal
+enforces Rails host authorization on `POSTAL_WEB_HOSTNAME`, so a request
+carrying any other `Host` header is rejected with a blank `403` and no mail
+leaves — silently, since the body is empty. A `postal send failed: HTTP 403 {}`
+line in a run is that host mismatch, not a bad key. (The internal address can't
+be salvaged with a `Host` override either: `fetch`/undici ignores a manual
+`Host` header.)
+
+`BEHOLDER_POSTAL_API_KEY` is a Postal API credential; the mail server must be
+Live and the sending domain (`${BASE_DOMAIN}`) verified.
 
 ## Development
 

--- a/stacks/apps/beholder/docker-compose.yml
+++ b/stacks/apps/beholder/docker-compose.yml
@@ -13,7 +13,10 @@ services:
             - ACTUAL_PASSWORD=${ACTUAL_PASSWORD}
             - ACTUAL_BUDGET_SYNC_ID=${ACTUAL_BUDGET_SYNC_ID}
             # Postal (house mail API) — beholder's own credential
-            - BEHOLDER_POSTAL_URL=http://postal_web:5000
+            # Postal enforces host authorization on POSTAL_WEB_HOSTNAME, so the
+            # HTTP API must be reached via the traefik hostname, not the internal
+            # service name (postal_web:5000 → blank 403). See README.
+            - BEHOLDER_POSTAL_URL=https://postal.${BASE_DOMAIN}
             - BEHOLDER_POSTAL_API_KEY=${BEHOLDER_POSTAL_API_KEY}
             - BEHOLDER_ALERT_FROM=budget@${BASE_DOMAIN}
             - BEHOLDER_ALERT_TO=${BEHOLDER_ALERT_TO}


### PR DESCRIPTION
## Why
Even on runs that didn't crash, beholder never delivered mail. It posts to Postal at `http://postal_web:5000` (internal service name), but Postal enforces Rails host authorization on `POSTAL_WEB_HOSTNAME`, so any request whose `Host` header isn't `postal.${BASE_DOMAIN}` is rejected with a **blank 403** — silently. That's the real reason no alert emails ever arrived.

Confirmed live: same socket, `Host: postal_web:5000` -> 403, `Host: postal.diyhub.dev` -> 302; and a send through `https://postal.${BASE_DOMAIN}` with beholder's real key -> **200 success**, message delivered. `fetch`/undici ignores a manual `Host` override, so the internal URL can't be salvaged in place.

## What
- `docker-compose.yml`: `BEHOLDER_POSTAL_URL` -> `https://postal.${BASE_DOMAIN}` (the traefik route, per Postal's README convention).
- `README.md`: new **Postal integration** section documenting the host-auth requirement and the blank-403 symptom; fixed stale "four checks" -> five.