### PR TITLE
0.3 · Make idempotence measurable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,11 +11,15 @@ on:
     pull_request:
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
+            - "ansible/**"
+            - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"
     push:
         branches: [main]
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
+            - "ansible/**"
+            - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"
 
 concurrency:
@@ -39,3 +43,32 @@ jobs:
             # restores into a scratch Postgres, asserts the row count).
             - name: Run e2e tier
               run: uv run ci test --tier e2e
+
+    # Idempotence: bootstrap the runner, then bootstrap it again. The second run
+    # must report changed=0 — the evidence that a re-run against converged
+    # infrastructure does nothing, which is what "re-running is the resume" needs.
+    # The runner is the disposable target; it is thrown away either way.
+    idempotence:
+        name: Ansible idempotence
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v5
+              with:
+                  enable-cache: true
+
+            - name: Install dependencies
+              run: uv sync
+
+            # ssh and snmp read group_vars that are gitignored, so they cannot run
+            # here. What remains — common, docker, cifs — is the real convergence
+            # surface: apt packages, directories, the Docker repo and engine.
+            - name: Bootstrap twice, require no change on the second run
+              env:
+                  ANSIBLE_CONFIG: ansible/ansible.cfg
+              run: >-
+                  uv run ci idempotence ansible/playbooks/bootstrap.yml
+                  --become -i ansible/inventory/ -i tests/ansible/idempotence/hosts.yml
+                  --limit ci-node --skip-tags ssh,snmp

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,5 +64,5 @@ jobs:
             - name: Install dependencies
               run: task install
 
-            - name: Bootstrap twice, require no change on the second run
+            - name: Run each enrolled playbook twice
               run: task ansible:test:idempotence --yes

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,10 +44,6 @@ jobs:
             - name: Run e2e tier
               run: uv run ci test --tier e2e
 
-    # Idempotence: bootstrap the runner, then bootstrap it again. The second run
-    # must report changed=0 — the evidence that a re-run against converged
-    # infrastructure does nothing, which is what "re-running is the resume" needs.
-    # The runner is the disposable target; it is thrown away either way.
     idempotence:
         name: Ansible idempotence
         runs-on: ubuntu-latest
@@ -59,16 +55,14 @@ jobs:
               with:
                   enable-cache: true
 
-            - name: Install dependencies
-              run: uv sync
+            - name: Install Task
+              uses: arduino/setup-task@v1
+              with:
+                  version: 3.x
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-            # ssh and snmp read group_vars that are gitignored, so they cannot run
-            # here. What remains — common, docker, cifs — is the real convergence
-            # surface: apt packages, directories, the Docker repo and engine.
+            - name: Install dependencies
+              run: task install
+
             - name: Bootstrap twice, require no change on the second run
-              env:
-                  ANSIBLE_CONFIG: ansible/ansible.cfg
-              run: >-
-                  uv run ci idempotence ansible/playbooks/bootstrap.yml
-                  --become -i ansible/inventory/ -i tests/ansible/idempotence/hosts.yml
-                  --limit ci-node --skip-tags ssh,snmp
+              run: task ansible:test:idempotence --yes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,12 +98,7 @@ repos:
             name: No unconditional changed_when in Ansible tasks
             language: pygrep
             entry: 'changed_when:\s*true\s*$'
-            # A task that always reports a change makes `changed=0` unreachable, so a
-            # second run can never prove it converged. Declare the real condition
-            # (`changed_when: result.rc == 0`) or `false` for a read-only probe.
-            # The exclusions are the ratchet: they name what is not clean yet and only
-            # ever shrink. preflight's two are the hooks.sh calls — Ansible cannot judge
-            # what an arbitrary script did, and 3.9 removes them.
+            # The exclusions are the ratchet: they only ever shrink.
             files: ^ansible/.*\.ya?ml$
             exclude: |
                 (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,23 @@ repos:
                 fi; fi; done'
             language: system
             pass_filenames: false
+
+          - id: no-unconditional-changed-when
+            name: No unconditional changed_when in Ansible tasks
+            language: pygrep
+            entry: 'changed_when:\s*true\s*$'
+            # A task that always reports a change makes `changed=0` unreachable, so a
+            # second run can never prove it converged. Declare the real condition
+            # (`changed_when: result.rc == 0`) or `false` for a read-only probe.
+            # The exclusions are the ratchet: they name what is not clean yet and only
+            # ever shrink. preflight's two are the hooks.sh calls — Ansible cannot judge
+            # what an arbitrary script did, and 3.9 removes them.
+            files: ^ansible/.*\.ya?ml$
+            exclude: |
+                (?x)^(
+                  ansible/collections/|
+                  ansible/playbooks/ops/repair-storage\.yml$|
+                  ansible/roles/preflight/tasks/main\.yml$|
+                  ansible/roles/secrets/tasks/adapters/bitwarden\.yml$|
+                  ansible/roles/storage/tasks/iscsi-unmount\.yml$
+                )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,8 +108,5 @@ repos:
             exclude: |
                 (?x)^(
                   ansible/collections/|
-                  ansible/playbooks/ops/repair-storage\.yml$|
-                  ansible/roles/preflight/tasks/main\.yml$|
-                  ansible/roles/secrets/tasks/adapters/bitwarden\.yml$|
-                  ansible/roles/storage/tasks/iscsi-unmount\.yml$
+                  ansible/roles/preflight/tasks/main\.yml$
                 )

--- a/ansible/Taskfile.yml
+++ b/ansible/Taskfile.yml
@@ -583,15 +583,20 @@ tasks:
             - "{{.VENV_ANSIBLE_PLAYBOOK}} -i ansible/inventory/ tests/ansible/integration/test-preflight.yml -K {{.CLI_ARGS}}"
 
     test:idempotence:
-        desc: "DESTRUCTIVE to the target: run bootstrap twice on THIS machine and require changed=0 on the second"
+        desc: "DESTRUCTIVE to the target: run each enrolled playbook twice on THIS machine, requiring changed=0 on the second"
         dir: "{{.ROOT_DIR}}"
-        prompt: "This bootstraps the local machine (installs packages, Docker). Only run it on a disposable node."
+        prompt: "This converges the local machine (installs packages, Docker). Only run it on a disposable node."
+        vars:
+            # Enrolled playbooks. Grows as targets CI can converge become available;
+            # anything needing a real cluster is run by hand against one.
+            PLAYBOOKS: ansible/playbooks/bootstrap.yml
         # ssh and snmp read group_vars that are gitignored, so they are absent in CI.
         cmds:
-            - >-
-                uv run ci idempotence ansible/playbooks/bootstrap.yml
-                --become -i ansible/inventory/ -i tests/ansible/idempotence/hosts.yml
-                --limit ci-node --skip-tags ssh,snmp {{.CLI_ARGS}}
+            - for: {var: PLAYBOOKS}
+              cmd: >-
+                  uv run ci idempotence {{.ITEM}}
+                  --become -i ansible/inventory/ -i tests/ansible/idempotence/hosts.yml
+                  --limit ci-node --skip-tags ssh,snmp {{.CLI_ARGS}}
 
     secrets:wipe:
         desc: "DESTRUCTIVE: Securely remove local secret files (.env, ansible hosts, ssh config)"

--- a/ansible/Taskfile.yml
+++ b/ansible/Taskfile.yml
@@ -582,6 +582,18 @@ tasks:
         cmds:
             - "{{.VENV_ANSIBLE_PLAYBOOK}} -i ansible/inventory/ tests/ansible/integration/test-preflight.yml -K {{.CLI_ARGS}}"
 
+    test:idempotence:
+        desc: "DESTRUCTIVE to the target: run bootstrap twice on THIS machine and require changed=0 on the second"
+        dir: "{{.ROOT_DIR}}"
+        prompt: "This bootstraps the local machine (installs packages, Docker). Only run it on a disposable node."
+        # ssh and snmp are skipped: both read group_vars that are gitignored, so
+        # they are absent in CI. --limit keeps this off the real hosts in 02-hosts.yml.
+        cmds:
+            - >-
+                uv run ci idempotence ansible/playbooks/bootstrap.yml
+                --become -i ansible/inventory/ -i tests/ansible/idempotence/hosts.yml
+                --limit ci-node --skip-tags ssh,snmp {{.CLI_ARGS}}
+
     secrets:wipe:
         desc: "DESTRUCTIVE: Securely remove local secret files (.env, ansible hosts, ssh config)"
         dir: "{{.ROOT_DIR}}"

--- a/ansible/Taskfile.yml
+++ b/ansible/Taskfile.yml
@@ -586,8 +586,7 @@ tasks:
         desc: "DESTRUCTIVE to the target: run bootstrap twice on THIS machine and require changed=0 on the second"
         dir: "{{.ROOT_DIR}}"
         prompt: "This bootstraps the local machine (installs packages, Docker). Only run it on a disposable node."
-        # ssh and snmp are skipped: both read group_vars that are gitignored, so
-        # they are absent in CI. --limit keeps this off the real hosts in 02-hosts.yml.
+        # ssh and snmp read group_vars that are gitignored, so they are absent in CI.
         cmds:
             - >-
                 uv run ci idempotence ansible/playbooks/bootstrap.yml

--- a/ansible/inventory/01-structure.yml
+++ b/ansible/inventory/01-structure.yml
@@ -18,4 +18,3 @@ all:
     vars:
         # Global settings (no secrets!)
         ansible_python_interpreter: /usr/bin/python3
-        bootstrap_version: "1.0.0"

--- a/ansible/inventory/group_vars/all/main.yml
+++ b/ansible/inventory/group_vars/all/main.yml
@@ -6,10 +6,6 @@
 # Domain configuration
 base_domain: "{{ lookup('env', 'BASE_DOMAIN') }}"
 
-# Bootstrap configuration
-bootstrap_state_dir: /var/lib/homelab
-bootstrap_version: "1.0.0"
-
 # Packages installed on every node during bootstrap.
 # Add a package here to install it. Feature roles gate on their key package
 # being present (e.g. 'snmpd' in packages enables SNMP configuration).

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -11,7 +11,6 @@
           Bootstrapping {{ inventory_hostname }}
           IP: {{ ansible_host }}
           User: {{ ansible_user }}
-          Version: {{ bootstrap_version }}
 
     - name: Gather facts
       setup:
@@ -21,27 +20,6 @@
           - hardware
           - network
           - virtual
-
-    - name: Check if node was previously bootstrapped
-      stat:
-        path: "{{ bootstrap_state_dir }}/bootstrap-state.json"
-      register: bootstrap_state_file
-
-    - name: Read previous bootstrap state
-      when: bootstrap_state_file.stat.exists
-      slurp:
-        src: "{{ bootstrap_state_dir }}/bootstrap-state.json"
-      register: previous_state
-
-    - name: Parse previous state
-      when: bootstrap_state_file.stat.exists
-      set_fact:
-        previous_bootstrap_version: "{{ (previous_state.content | b64decode | from_json).version }}"
-
-    - name: Display previous state
-      when: bootstrap_state_file.stat.exists
-      debug:
-        msg: "Previous bootstrap version: {{ previous_bootstrap_version }}"
 
   roles:
     - role: ../roles/common
@@ -76,39 +54,6 @@
     #   tags: ['firewall', 'security']
 
   post_tasks:
-    - name: Create bootstrap state directory
-      file:
-        path: "{{ bootstrap_state_dir }}"
-        state: directory
-        mode: '0755'
-
-    - name: Generate bootstrap state
-      copy:
-        content: |
-          {
-            "version": "{{ bootstrap_version }}",
-            "last_run": "{{ ansible_date_time.iso8601 }}",
-            "hostname": "{{ ansible_hostname }}",
-            "completed_roles": {{ ansible_play_role_names | to_json }},
-            "system_info": {
-              "os": "{{ ansible_distribution }} {{ ansible_distribution_version }}",
-              "arch": "{{ ansible_architecture }}",
-              "kernel": "{{ ansible_kernel }}",
-              "memory_mb": {{ ansible_memtotal_mb }},
-              "cpu_cores": {{ ansible_processor_vcpus }}
-            },
-            "docker_info": {
-              "version": "{{ docker_installed_version | default('unknown') }}",
-              "compose_version": "{{ docker_compose_installed_version | default('unknown') }}"
-            },
-            "gpu_detected": {{ gpu_present | default(false) | to_json }}
-          }
-        dest: "{{ bootstrap_state_dir }}/bootstrap-state.json"
-        mode: '0644'
-
     - name: Display completion message
       debug:
-        msg: |
-          ✓ Bootstrap complete for {{ inventory_hostname }}
-          Version: {{ bootstrap_version }}
-          State file: {{ bootstrap_state_dir }}/bootstrap-state.json
+        msg: "✓ Bootstrap complete for {{ inventory_hostname }}"

--- a/ansible/playbooks/ops/repair-storage.yml
+++ b/ansible/playbooks/ops/repair-storage.yml
@@ -105,8 +105,7 @@
         - fsck_force | bool
       register: storage_fsck_result
       failed_when: false
-      # This play treats any non-zero rc as a hard failure two tasks below, so a
-      # clean exit is the only outcome that repaired anything.
+      # Any non-zero rc is a hard failure two tasks below.
       changed_when: storage_fsck_result.rc == 0
 
     - name: "[PHASE 3] Display fsck results"

--- a/ansible/playbooks/ops/repair-storage.yml
+++ b/ansible/playbooks/ops/repair-storage.yml
@@ -105,7 +105,9 @@
         - fsck_force | bool
       register: storage_fsck_result
       failed_when: false
-      changed_when: true
+      # This play treats any non-zero rc as a hard failure two tasks below, so a
+      # clean exit is the only outcome that repaired anything.
+      changed_when: storage_fsck_result.rc == 0
 
     - name: "[PHASE 3] Display fsck results"
       ansible.builtin.debug:

--- a/ansible/playbooks/update.yml
+++ b/ansible/playbooks/update.yml
@@ -28,9 +28,3 @@
       import_role:
         name: ../roles/docker
       tags: ['docker']
-
-    - name: Update bootstrap state
-      shell: |
-        jq '.last_updated = "{{ ansible_date_time.iso8601 }}"'
-          {{ bootstrap_state_dir }}/bootstrap-state.json > /tmp/state.json
-        mv /tmp/state.json {{ bootstrap_state_dir }}/bootstrap-state.json

--- a/ansible/playbooks/validate.yml
+++ b/ansible/playbooks/validate.yml
@@ -38,19 +38,9 @@
         port: 53
         timeout: 5
 
-    - name: Read bootstrap state
-      slurp:
-        src: "{{ bootstrap_state_dir }}/bootstrap-state.json"
-      register: state_file
-
-    - name: Parse and display state
-      debug:
-        msg: "{{ state_file.content | b64decode | from_json }}"
-
     - name: Validation summary
       debug:
         msg: |
           ✓ Docker running: {{ docker_service.changed == false }}
           ✓ Disk usage: {{ disk_usage.stdout }}%
           ✓ Memory: {{ ansible_memtotal_mb }}MB
-          ✓ Bootstrap version: {{ (state_file.content | b64decode | from_json).version }}

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -24,4 +24,3 @@
   loop:
       - /opt/homelab
       - /var/log/homelab
-      - "{{ bootstrap_state_dir }}"

--- a/ansible/roles/preflight/tasks/main.yml
+++ b/ansible/roles/preflight/tasks/main.yml
@@ -74,13 +74,12 @@
   register: preflight_hook_mode
   when: preflight_hooks_stat.stat.exists
 
+# Ansible cannot know what an arbitrary hooks.sh did. Removed with it in 3.9.
 - name: Run pre-deploy hook as root
   ansible.builtin.command:
     cmd: "bash {{ preflight_stack_path }}/hooks.sh pre_deploy"
   delegate_to: localhost
   become: true
-  # hooks.sh is an arbitrary per-stack script, so Ansible cannot know what it did;
-  # an unconditional change is the only honest answer. Removed with hooks.sh in 3.9.
   changed_when: true
   environment: "{{ swarm_env_vars | combine({
     'DOCKER_CONFIG': lookup('env', 'HOME') + '/.docker',
@@ -94,8 +93,6 @@
   ansible.builtin.command:
     cmd: "bash {{ preflight_stack_path }}/hooks.sh pre_deploy"
   delegate_to: localhost
-  # hooks.sh is an arbitrary per-stack script, so Ansible cannot know what it did;
-  # an unconditional change is the only honest answer. Removed with hooks.sh in 3.9.
   changed_when: true
   environment: "{{ swarm_env_vars | combine({
     'DOCKER_CONFIG': lookup('env', 'HOME') + '/.docker',

--- a/ansible/roles/preflight/tasks/main.yml
+++ b/ansible/roles/preflight/tasks/main.yml
@@ -79,6 +79,8 @@
     cmd: "bash {{ preflight_stack_path }}/hooks.sh pre_deploy"
   delegate_to: localhost
   become: true
+  # hooks.sh is an arbitrary per-stack script, so Ansible cannot know what it did;
+  # an unconditional change is the only honest answer. Removed with hooks.sh in 3.9.
   changed_when: true
   environment: "{{ swarm_env_vars | combine({
     'DOCKER_CONFIG': lookup('env', 'HOME') + '/.docker',
@@ -92,6 +94,8 @@
   ansible.builtin.command:
     cmd: "bash {{ preflight_stack_path }}/hooks.sh pre_deploy"
   delegate_to: localhost
+  # hooks.sh is an arbitrary per-stack script, so Ansible cannot know what it did;
+  # an unconditional change is the only honest answer. Removed with hooks.sh in 3.9.
   changed_when: true
   environment: "{{ swarm_env_vars | combine({
     'DOCKER_CONFIG': lookup('env', 'HOME') + '/.docker',

--- a/ansible/roles/secrets/tasks/adapters/bitwarden.yml
+++ b/ansible/roles/secrets/tasks/adapters/bitwarden.yml
@@ -22,7 +22,6 @@
         - name: Bitwarden | Install CLI via npm if missing or broken
           ansible.builtin.command: npm install -g @bitwarden/cli
           when: secrets_bw_check.rc != 0
-          changed_when: true
 
     - name: Bitwarden | Check if logged in
       ansible.builtin.command: bw status
@@ -401,7 +400,6 @@
                 stdin: "{{ secrets_new_bw_item | to_json }}"
               register: secrets_bw_created_item_raw
               no_log: true
-              changed_when: true
 
             - name: Bitwarden | Set item ID from newly created item
               ansible.builtin.set_fact:
@@ -436,7 +434,6 @@
             secrets_bw_item_found and
             (secrets_bw_item.attachments | default([]) | selectattr('fileName', 'equalto', 'secrets.env') | list | length) > 0
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Write secrets.env to temp directory
           ansible.builtin.copy:
@@ -451,7 +448,6 @@
             --file {{ secrets_bw_push_temp_dir.path }}/secrets.env
             --itemid {{ secrets_bw_push_item_id }}
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Delete existing hosts.yml attachment if present
           ansible.builtin.command: >-
@@ -469,7 +465,6 @@
             secrets_bw_item_found and
             (secrets_bw_item.attachments | default([]) | selectattr('fileName', 'equalto', 'hosts.yml') | list | length) > 0
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Write hosts.yml to temp directory
           ansible.builtin.copy:
@@ -486,7 +481,6 @@
             --itemid {{ secrets_bw_push_item_id }}
           when: secrets_hosts_content is defined
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Delete existing ansible-ssh.yml attachment if present
           ansible.builtin.command: >-
@@ -504,7 +498,6 @@
             secrets_bw_item_found and
             (secrets_bw_item.attachments | default([]) | selectattr('fileName', 'equalto', 'ansible-ssh.yml') | list | length) > 0
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Write ansible-ssh.yml to temp directory
           ansible.builtin.copy:
@@ -521,7 +514,6 @@
             --itemid {{ secrets_bw_push_item_id }}
           when: secrets_ssh_content is defined
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Delete existing ansible-snmp.yml attachment if present
           ansible.builtin.command: >-
@@ -539,7 +531,6 @@
             secrets_bw_item_found and
             (secrets_bw_item.attachments | default([]) | selectattr('fileName', 'equalto', 'ansible-snmp.yml') | list | length) > 0
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Write ansible-snmp.yml to temp directory
           ansible.builtin.copy:
@@ -556,7 +547,6 @@
             --itemid {{ secrets_bw_push_item_id }}
           when: secrets_snmp_content is defined
           no_log: true
-          changed_when: true
 
         - name: Bitwarden | Remove temp directory
           ansible.builtin.file:

--- a/ansible/roles/storage/tasks/iscsi-unmount.yml
+++ b/ansible/roles/storage/tasks/iscsi-unmount.yml
@@ -107,8 +107,11 @@
     - item.item.enabled | bool
     - item.item.mount_path is defined
     - item.rc == 0
+  register: storage_fuser_kill
   failed_when: false
-  changed_when: true
+  # fuser exits 0 only when it matched and signalled a process; 1 means there was
+  # nothing to kill. Reporting a change on 1 hides that under failed_when: false.
+  changed_when: storage_fuser_kill.rc == 0
 
 - name: Force unmount remaining OCFS2 filesystems
   ansible.builtin.command: umount -f {{ item.item.mount_path }}
@@ -117,8 +120,11 @@
     - item.item.enabled | bool
     - item.item.mount_path is defined
     - item.rc == 0
+  register: storage_force_umount
   failed_when: false
-  changed_when: true
+  # A failed umount left the mount in place — that is not a change, and
+  # failed_when: false means nothing else would surface it.
+  changed_when: storage_force_umount.rc == 0
 
 # ── Step 4: VERIFY mounts are gone ────────────────────────────────────────
 

--- a/ansible/roles/storage/tasks/iscsi-unmount.yml
+++ b/ansible/roles/storage/tasks/iscsi-unmount.yml
@@ -109,8 +109,7 @@
     - item.rc == 0
   register: storage_fuser_kill
   failed_when: false
-  # fuser exits 0 only when it matched and signalled a process; 1 means there was
-  # nothing to kill. Reporting a change on 1 hides that under failed_when: false.
+  # fuser exits 0 only when it signalled something; 1 means there was nothing to kill.
   changed_when: storage_fuser_kill.rc == 0
 
 - name: Force unmount remaining OCFS2 filesystems
@@ -122,8 +121,6 @@
     - item.rc == 0
   register: storage_force_umount
   failed_when: false
-  # A failed umount left the mount in place — that is not a change, and
-  # failed_when: false means nothing else would surface it.
   changed_when: storage_force_umount.rc == 0
 
 # ── Step 4: VERIFY mounts are gone ────────────────────────────────────────

--- a/tests/ansible/idempotence/hosts.yml
+++ b/tests/ansible/idempotence/hosts.yml
@@ -1,0 +1,16 @@
+# tests/ansible/idempotence/hosts.yml
+# A disposable single-node target for the idempotence check.
+#
+# Layered on top of ansible/inventory/ rather than replacing it, so `packages`
+# and the rest of group_vars/all are the real ones — nothing is duplicated here.
+# The real hosts live in 02-hosts.yml, which is gitignored and therefore absent
+# in CI; --limit keeps this to the local node when it is present.
+---
+all:
+  children:
+    managers:
+      hosts:
+        ci-node:
+          ansible_connection: local
+          ansible_host: 127.0.0.1
+          ansible_user: "{{ lookup('env', 'USER') | default('runner', true) }}"

--- a/tests/ansible/idempotence/hosts.yml
+++ b/tests/ansible/idempotence/hosts.yml
@@ -1,10 +1,5 @@
 # tests/ansible/idempotence/hosts.yml
-# A disposable single-node target for the idempotence check.
-#
-# Layered on top of ansible/inventory/ rather than replacing it, so `packages`
-# and the rest of group_vars/all are the real ones — nothing is duplicated here.
-# The real hosts live in 02-hosts.yml, which is gitignored and therefore absent
-# in CI; --limit keeps this to the local node when it is present.
+# A disposable single-node target, layered on ansible/inventory/ so group_vars is the real one.
 ---
 all:
   children:

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -6,6 +6,7 @@ Subcommands:
   ci test [SELECTOR] [--tier T] [--affected]   run app pytest suites by tier
   ci images [REPO_ROOT]                 list every buildable image name (one per line)
   ci gc [--apply] [--cutoff-days N]     prune stale :sha/untagged ghcr versions (dry-run by default)
+  ci idempotence PLAYBOOK [ANSIBLE ARGS] run a playbook twice; fail unless the second changes nothing
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import json
 import subprocess
 import sys
 
-from ci import affected, apptests, gc
+from ci import affected, apptests, gc, idempotence
 
 
 def _cmd_affected(args: argparse.Namespace) -> int:
@@ -60,6 +61,10 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_idempotence(args: argparse.Namespace) -> int:
+    return idempotence.verify(args.playbook, args.ansible_args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ci")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -86,6 +91,13 @@ def build_parser() -> argparse.ArgumentParser:
     gc_p.add_argument("--cutoff-days", type=int, default=14)
     gc_p.add_argument("--apply", action="store_true", help="actually delete (default: dry-run)")
     gc_p.set_defaults(func=_cmd_gc)
+
+    idem = sub.add_parser("idempotence", help="run a playbook twice; the second must change nothing")
+    idem.add_argument("playbook")
+    # REMAINDER so ansible's own flags (-i, --limit, --skip-tags) pass through unparsed.
+    idem.add_argument("ansible_args", nargs=argparse.REMAINDER,
+                      help="passed through to ansible-playbook")
+    idem.set_defaults(func=_cmd_idempotence)
     return parser
 
 

--- a/tools/ci/ci/idempotence.py
+++ b/tools/ci/ci/idempotence.py
@@ -1,13 +1,8 @@
 """Second-run idempotence — the `ci idempotence` logic.
 
-An Ansible run that converges reports ``changed=0`` the second time. That number
-is the cheapest evidence we have that a playbook is declarative rather than
-imperative, and it is what "re-running is the resume" rests on: if a re-run
-against converged infrastructure genuinely does nothing, a killed run needs no
-recovery mode, only the same command again.
-
-:func:`parse_recap` and :func:`violations` are pure and unit-tested;
-:func:`verify` is the subprocess wrapper that runs the playbook twice.
+A converged playbook reports ``changed=0`` when run again. :func:`parse_recap`
+and :func:`violations` are pure and unit-tested; :func:`verify` runs the
+playbook twice.
 """
 
 from __future__ import annotations
@@ -17,23 +12,19 @@ import subprocess
 import sys
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
-_RECAP_HEADER = re.compile(r"^PLAY RECAP\b")
 _HOST_LINE = re.compile(r"^(?P<host>\S+)\s*:\s+(?P<counters>(?:\w+=\d+\s*)+)$")
-
-# A second run may not change anything, and must have actually run: a playbook
-# that died before touching the host also reports changed=0.
 _FATAL = ("failed", "unreachable")
 
 
 def parse_recap(output: str) -> dict[str, dict[str, int]]:
     """Host -> counter map, read from the PLAY RECAP block of an Ansible run.
 
-    Raises ValueError when there is no recap — a run that never got that far
-    proves nothing, and must not be mistaken for a clean one.
+    Raises ValueError when there is no recap: a run that died before reaching
+    one reports no changes either, and must not be mistaken for a clean run.
     """
     lines = _ANSI.sub("", output).splitlines()
     for i, line in enumerate(lines):
-        if _RECAP_HEADER.match(line):
+        if line.startswith("PLAY RECAP"):
             break
     else:
         raise ValueError("no PLAY RECAP in output — the run did not complete")
@@ -73,8 +64,8 @@ def verify(playbook: str, ansible_args: list[str] | None = None) -> int:
         result = subprocess.run(cmd, capture_output=True, text=True)
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
+
         if run == 1:
-            # The first run is allowed to change everything; it only has to work.
             if result.returncode != 0:
                 print(f"\n✗ first run failed (rc={result.returncode}) — nothing to compare")
                 return result.returncode
@@ -85,13 +76,10 @@ def verify(playbook: str, ansible_args: list[str] | None = None) -> int:
         except ValueError as exc:
             print(f"\n✗ {exc}")
             return 1
-        bad = violations(recap)
-        if bad:
+        if bad := violations(recap):
             print("\n✗ second run was not a no-op:")
             for host, why in sorted(bad.items()):
                 print(f"    {host}: {why}")
-            print("\n  A task reported a change against already-converged state. Give it a")
-            print("  real changed_when, or make it stop rewriting identical content.")
             return 1
         print(f"\n✓ second run reported no change on {len(recap)} host(s)")
     return 0

--- a/tools/ci/ci/idempotence.py
+++ b/tools/ci/ci/idempotence.py
@@ -1,0 +1,97 @@
+"""Second-run idempotence — the `ci idempotence` logic.
+
+An Ansible run that converges reports ``changed=0`` the second time. That number
+is the cheapest evidence we have that a playbook is declarative rather than
+imperative, and it is what "re-running is the resume" rests on: if a re-run
+against converged infrastructure genuinely does nothing, a killed run needs no
+recovery mode, only the same command again.
+
+:func:`parse_recap` and :func:`violations` are pure and unit-tested;
+:func:`verify` is the subprocess wrapper that runs the playbook twice.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_RECAP_HEADER = re.compile(r"^PLAY RECAP\b")
+_HOST_LINE = re.compile(r"^(?P<host>\S+)\s*:\s+(?P<counters>(?:\w+=\d+\s*)+)$")
+
+# A second run may not change anything, and must have actually run: a playbook
+# that died before touching the host also reports changed=0.
+_FATAL = ("failed", "unreachable")
+
+
+def parse_recap(output: str) -> dict[str, dict[str, int]]:
+    """Host -> counter map, read from the PLAY RECAP block of an Ansible run.
+
+    Raises ValueError when there is no recap — a run that never got that far
+    proves nothing, and must not be mistaken for a clean one.
+    """
+    lines = _ANSI.sub("", output).splitlines()
+    for i, line in enumerate(lines):
+        if _RECAP_HEADER.match(line):
+            break
+    else:
+        raise ValueError("no PLAY RECAP in output — the run did not complete")
+
+    recap: dict[str, dict[str, int]] = {}
+    for line in lines[i + 1:]:
+        match = _HOST_LINE.match(line.strip())
+        if not match:
+            if recap:  # the block ended
+                break
+            continue
+        recap[match.group("host")] = {
+            k: int(v) for k, v in (p.split("=") for p in match.group("counters").split())
+        }
+    if not recap:
+        raise ValueError("PLAY RECAP names no hosts")
+    return recap
+
+
+def violations(recap: dict[str, dict[str, int]]) -> dict[str, str]:
+    """Hosts whose second run was not a no-op, mapped to why."""
+    out = {}
+    for host, counters in recap.items():
+        fatal = [k for k in _FATAL if counters.get(k)]
+        if fatal:
+            out[host] = ", ".join(f"{k}={counters[k]}" for k in fatal)
+        elif counters.get("changed"):
+            out[host] = f"changed={counters['changed']}"
+    return out
+
+
+def verify(playbook: str, ansible_args: list[str] | None = None) -> int:
+    """Run the playbook twice; fail if the second run reports any change."""
+    cmd = ["ansible-playbook", playbook, *(ansible_args or [])]
+    for run in (1, 2):
+        print(f"\n=== idempotence: run {run}/2 — {' '.join(cmd)}\n", flush=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if run == 1:
+            # The first run is allowed to change everything; it only has to work.
+            if result.returncode != 0:
+                print(f"\n✗ first run failed (rc={result.returncode}) — nothing to compare")
+                return result.returncode
+            continue
+
+        try:
+            recap = parse_recap(result.stdout)
+        except ValueError as exc:
+            print(f"\n✗ {exc}")
+            return 1
+        bad = violations(recap)
+        if bad:
+            print("\n✗ second run was not a no-op:")
+            for host, why in sorted(bad.items()):
+                print(f"    {host}: {why}")
+            print("\n  A task reported a change against already-converged state. Give it a")
+            print("  real changed_when, or make it stop rewriting identical content.")
+            return 1
+        print(f"\n✓ second run reported no change on {len(recap)} host(s)")
+    return 0

--- a/tools/ci/tests/test_idempotence.py
+++ b/tools/ci/tests/test_idempotence.py
@@ -1,0 +1,78 @@
+"""Tests for the second-run idempotence verdict (the `ci idempotence` logic).
+
+The pure part reads a PLAY RECAP and decides whether the second run was a no-op.
+The dangerous case is a false pass: a run that failed, never reached a recap, or
+touched no hosts must not read as clean. Driving ansible-playbook is glue.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ci.idempotence import parse_recap, violations
+
+CONVERGED = """
+PLAY RECAP *********************************************************************
+manager-01                 : ok=42   changed=0    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0
+worker-01                  : ok=38   changed=0    unreachable=0    failed=0    skipped=9    rescued=0    ignored=0
+"""
+
+DRIFTED = """
+PLAY RECAP *********************************************************************
+manager-01                 : ok=42   changed=3    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0
+worker-01                  : ok=38   changed=0    unreachable=0    failed=0    skipped=9    rescued=0    ignored=0
+"""
+
+
+def test_parses_every_counter_for_every_host():
+    recap = parse_recap(CONVERGED)
+    assert set(recap) == {"manager-01", "worker-01"}
+    assert recap["manager-01"]["ok"] == 42
+    assert recap["manager-01"]["skipped"] == 7
+    assert recap["worker-01"]["changed"] == 0
+
+
+def test_converged_second_run_has_no_violations():
+    assert violations(parse_recap(CONVERGED)) == {}
+
+
+def test_names_only_the_host_that_changed():
+    assert violations(parse_recap(DRIFTED)) == {"manager-01": "changed=3"}
+
+
+@pytest.mark.parametrize(
+    "counters, expected",
+    [
+        ("ok=1    changed=0    unreachable=1    failed=0", "unreachable=1"),
+        ("ok=1    changed=0    unreachable=0    failed=2", "failed=2"),
+        # A failure outranks the change count: the run proved nothing either way.
+        ("ok=1    changed=5    unreachable=0    failed=2", "failed=2"),
+    ],
+)
+def test_a_failed_run_is_a_violation_even_with_no_changes(counters, expected):
+    recap = parse_recap(f"PLAY RECAP ****\nnode-01                    : {counters}\n")
+    assert violations(recap) == {"node-01": expected}
+
+
+def test_ansi_coloured_output_still_parses():
+    coloured = (
+        "PLAY RECAP ****\n"
+        "\x1b[0;32mnode-01                    : ok=3    changed=0    "
+        "unreachable=0    failed=0\x1b[0m\n"
+    )
+    assert violations(parse_recap(coloured)) == {}
+
+
+def test_trailing_output_after_the_recap_is_ignored():
+    trailing = CONVERGED + "\nSunday 23 August 2026  17:03:05 -0400 (0:00:00.737)\nsome task  0.74s\n"
+    assert violations(parse_recap(trailing)) == {}
+
+
+def test_a_run_with_no_recap_raises_rather_than_passing():
+    with pytest.raises(ValueError, match="no PLAY RECAP"):
+        parse_recap("ERROR! the playbook could not be found\n")
+
+
+def test_a_recap_naming_no_hosts_raises():
+    with pytest.raises(ValueError, match="no hosts"):
+        parse_recap("PLAY RECAP ****\n\n")

--- a/tools/ci/tests/test_idempotence.py
+++ b/tools/ci/tests/test_idempotence.py
@@ -45,7 +45,6 @@ def test_names_only_the_host_that_changed():
     [
         ("ok=1    changed=0    unreachable=1    failed=0", "unreachable=1"),
         ("ok=1    changed=0    unreachable=0    failed=2", "failed=2"),
-        # A failure outranks the change count: the run proved nothing either way.
         ("ok=1    changed=5    unreachable=0    failed=2", "failed=2"),
     ],
 )


### PR DESCRIPTION
Closes #109.

`changed=0` is the cheapest evidence that a playbook is declarative rather than imperative, and
phase 1's "re-running is the resume" rests entirely on it. Fifteen tasks declared
`changed_when: true`, so the number could never read 0 no matter how converged the cluster was.

**Baseline: 15 → 2.** The two survivors are the `hooks.sh pre_deploy` calls, now commented and
named in the hook's `exclude:` — the ratchet entry 3.9 removes.

### The check landed first

A `pygrep` hook over `ansible/`, with `exclude:` as the baseline (per #108 — no harness, no count
file). It went in red-capable with all four offending files excluded; the fixes and the narrowed
exclude are the next commit, so the ratchet motion is visible in history.

Verified disjoint from ansible-lint's `no-changed-when`: that rule fires on a *missing*
declaration and ignores `changed_when: true`. It is also currently off (repo is `profile: basic`;
the rule lives in `shared`) and would surface 24 violations today — its own story.

### Three real defect fixes

`iscsi-unmount.yml` ×2 and `repair-storage.yml` ×1 paired `changed_when: true` with
`failed_when: false`, so a **failed** `umount -f` or `fuser -km` reported *changed and OK*. Now
`changed_when: <register>.rc == 0`, matching the idiom already dominant in the tree.

Verified against a reproduction of the exact task shape — loop over a prior task's `.results`,
multi-condition `when:`, `register` + `failed_when: false`:

```
changed=[True, False, False]   skipped=[False, False, True]
```

rc 0 → changed; rc 1 → not changed; the `when:`-skipped iteration never evaluates the expression,
so the converged-node path (where every iteration skips) cannot raise undefined.

### Ten bitwarden removals are behaviour-identical

Each of the ten sits on a `command`/`shell` task, where `changed_when: true` **is** the module
default — confirmed by walking each to its enclosing `- name:`. Removing them changes nothing at
runtime; those tasks still report changed, and they genuinely mutate the vault every time, so
there is no truer condition available. The gain is that `changed_when: true` now signals a
decision rather than boilerplate.

### The write-only bootstrap state file is gone

`bootstrap-state.json` recorded that bootstrap ran, and every one of its three consumers was a
`debug:` print — nothing branched on it, nothing was skipped because of it. Its `last_run`
timestamp made `bootstrap.yml` report changed forever, so it was the single thing standing between
the most important playbook and a provable `changed=0`. 77 lines across six files; no reference
remains. It also removed `update.yml`'s `jq`-patch task, a second always-changed task.

This is out of the issue's literal scope but squarely under its second acceptance criterion.

### Check I

`ci idempotence PLAYBOOK [ansible args]` — a subcommand on the existing `build_parser()`, using the
pure/glue split `gc.py` established. The parser refuses to call a run clean when there is no
`PLAY RECAP`, when the recap names no hosts, or when a host reports `failed`/`unreachable`: a run
that died also reports `changed=0`, and that must not read as a pass.

The CI inventory is 16 lines layered *on top of* `ansible/inventory/`, so `packages`,
`cifs_packages`, `docker_version` and the `iscsi_*` gates are the real ones — nothing duplicated.
The job went into `e2e.yml` rather than a sixth workflow, path-triggered on `ansible/**` the same
way that file already gates app e2e suites, and it calls `task ansible:test:idempotence` rather
than restating the invocation — one definition of the flags, the way `ci-cd.yml` calls `task lint`.

Playbooks are enrolled by an explicit list in that task verb, currently one entry. That mirrors the
`exclude:` idiom — a named set that only moves one way — rather than the e2e tier's directory
discovery, which is more machinery than one entry earns. `cluster.yml` is the obvious second
enrollee (its own header claims idempotence with nothing checking it) once CI can stand up a
single-node swarm; the deploy playbooks need a real cluster and run through the same verb by hand.
The shared `--become / --skip-tags` flags are the limit of this shape: the first enrollee needing
different ones is the signal to switch to discovery.

### Verification

- 10 new parser tests; 45 in the suite, all passing
- End-to-end against real `ansible-playbook`: idempotent fixture → exit 0; a fixture with
  `changed_when: true` → `✗ second run was not a no-op: localhost: changed=1`, exit 1
- `pre-commit run --all-files` green on every hook
- Rule 3 — the hook run twice is identical and reports no work
- Rule 2 (spec diff) does not apply: nothing here touches a compose file, stack or volume, so
  there is no `docker service inspect` to compare

### The check's first real run

The `Ansible idempotence` job ran on this PR and passed in 1m27s, against the runner as the
disposable target:

```
run 1/2:  ci-node : ok=29  changed=11  failed=0
run 2/2:  ci-node : ok=28  changed=0   failed=0
✓ second run reported no change on 1 host(s)
```

Run 1 did real work — 11 changes: apt packages, directories, the Docker GPG key and repo, the
pinned engine, the docker group, `daemon.json`, cifs-utils. Run 2 reported zero. No further
always-changed tasks surfaced beyond the state file.

`ssh` and `snmp` are skipped because both read group_vars that are gitignored, so they are absent
in CI. What remains — `common`, `docker`, `cifs` — is the real convergence surface.

### Left alone deliberately

`tests/ansible/integration/test-preflight.yml` has 2 more `changed_when: true` — outside
`ansible/` and outside the stated baseline of 15, so left for scheduling rather than fixed
silently.
