### PR TITLE
TEMP probe: image-only change must still build

### DIFF
--- a/images/devbox/Dockerfile
+++ b/images/devbox/Dockerfile
@@ -225,3 +225,5 @@ ENV VITE_IS_PLATFORM=true
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["sudo", "-E", "/usr/local/bin/devbox-start.sh"]
+
+# probe: verifying an image-only change still builds when no test project is affected


### PR DESCRIPTION
Throwaway. Verifies that a change producing build units but no test projects skips `test` and still runs `build`. Will be closed and both branches deleted.