### PR TITLE
1.2 · Report live state per stack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,8 @@ jobs:
                   else
                       files="$(git diff --name-only "$base"...HEAD)"
                   fi
-                  units="$(printf '%s\n' "$files" | uv run ci affected .)"
-                  projects="$(printf '%s\n' "$files" | uv run ci projects .)"
+                  units="$(printf '%s\n' "$files" | uv run ci affected)"
+                  projects="$(printf '%s\n' "$files" | uv run ci projects)"
                   echo "units=$units" >> "$GITHUB_OUTPUT"
                   echo "projects=$projects" >> "$GITHUB_OUTPUT"
                   echo "Affected units:    $units"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ on:
     pull_request:
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
+            - "tools/ci/tests/e2e/**"
             - "ansible/**"
             - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"
@@ -18,6 +19,7 @@ on:
         branches: [main]
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
+            - "tools/ci/tests/e2e/**"
             - "ansible/**"
             - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,17 +1,16 @@
 name: E2E tests
 
 # Heavier, orchestration-based end-to-end tests (the `e2e` tier), kept OUT of the
-# per-build gate in build.yml. Runs nightly, on demand, on main, and on PRs that
-# touch an e2e suite — so it stays non-blocking for normal app PRs.
+# per-build gate in build.yml. Runs on demand, on main, and on PRs that touch an
+# e2e suite or the code one covers — so it stays non-blocking for normal app PRs.
 
 on:
     workflow_dispatch:
-    schedule:
-        - cron: "0 6 * * *" # nightly 06:00 UTC
     pull_request:
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
             - "tools/ci/tests/e2e/**"
+            - "tools/ci/ci/**"
             - "ansible/**"
             - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"
@@ -20,6 +19,7 @@ on:
         paths:
             - "stacks/apps/*/**/tests/e2e/**"
             - "tools/ci/tests/e2e/**"
+            - "tools/ci/ci/**"
             - "ansible/**"
             - "tests/ansible/idempotence/**"
             - ".github/workflows/e2e.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
               # still get tagged — so the whole platform ends up on one version.
               run: |
                   set -euo pipefail
-                  for image in $(uv run ci images .); do
+                  for image in $(uv run ci images); do
                       repo="${REGISTRY}/${REGISTRY_NAMESPACE}/${image}"
                       docker buildx imagetools create "${repo}:latest" --tag "${repo}:${VERSION}"
                       echo "Promoted \`${repo}:${VERSION}\` (from \`:latest\`)." >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,15 @@ repos:
             language: system
             pass_filenames: false
 
+          - id: ci-types
+            name: Type-check the ci tool (mypy --strict)
+            entry: uv run --project tools/ci --with mypy mypy --strict --ignore-missing-imports
+            language: system
+            # The package only. `--strict` on the suite would demand annotations on
+            # every test function, which says nothing about the code under test.
+            files: ^tools/ci/ci/.*\.py$
+            require_serial: true
+
           - id: stack-deps-declared
             name: Stack dependencies declared in x-homelab.requires
             entry: uv run ci check-deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ deploy:
 
 **Stack dependencies** (`x-homelab.requires`, top-level in the compose file) — what must be
 converged before this stack deploys. `uv run ci deploy --plan [stack ...]` prints the resolved
-order; a cycle or a dependency on a stack that does not exist fails the pre-commit check.
+order with each stack's live state (`absent`, `present`, `converged`) and which target pulled it
+in; a cycle or a dependency on a stack that does not exist fails the pre-commit check.
 Anything a compose file gives away — a `traefik.enable=true` label, an `authentik@swarm`
 middleware, an `auth.${BASE_DOMAIN}` issuer — must be declared:
 ```yaml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -244,7 +244,7 @@ tasks:
             - task --list
 
     deploy:plan:
-        desc: "Print the resolved deploy order — task deploy:plan -- paperless (omit for every stack)"
+        desc: "Print the deploy plan and live state — task deploy:plan -- paperless (omit for every stack)"
         cmds:
             - uv run ci deploy --plan {{.CLI_ARGS}}
 

--- a/tools/ci/ci/adapters.py
+++ b/tools/ci/ci/adapters.py
@@ -8,7 +8,6 @@ as a pure function instead.
 from __future__ import annotations
 
 import subprocess
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -56,14 +55,3 @@ class Subprocess:
 class SystemClock:
     def now_timestamp(self) -> float:
         return datetime.now(tz=timezone.utc).timestamp()
-
-
-class StdoutOutput:
-    def line(self, text: str = "") -> None:
-        print(text)
-
-    def raw(self, text: str) -> None:
-        sys.stdout.write(text)
-
-    def raw_err(self, text: str) -> None:
-        sys.stderr.write(text)

--- a/tools/ci/ci/adapters.py
+++ b/tools/ci/ci/adapters.py
@@ -58,12 +58,12 @@ class SystemClock:
         return datetime.now(tz=timezone.utc).timestamp()
 
 
-class StdoutConsole:
-    def out(self, message: str = "") -> None:
-        print(message)
+class StdoutOutput:
+    def line(self, text: str = "") -> None:
+        print(text)
 
-    def err(self, message: str = "") -> None:
-        print(message, file=sys.stderr)
-
-    def write(self, text: str) -> None:
+    def raw(self, text: str) -> None:
         sys.stdout.write(text)
+
+    def raw_err(self, text: str) -> None:
+        sys.stderr.write(text)

--- a/tools/ci/ci/affected.py
+++ b/tools/ci/ci/affected.py
@@ -16,6 +16,7 @@ import fnmatch
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -56,7 +57,7 @@ class Unit:
         """Bare image name (last path segment), e.g. ``warden`` or ``homelab-devbox``."""
         return self.image_key.rsplit("/", 1)[-1]
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, str | None]:
         """JSON-serializable view shared by the build matrix and release resolution."""
         return {
             "service": self.service,
@@ -137,7 +138,7 @@ class UnitCatalog:
                 units.extend(self._units_in(compose_path, data))
         return units
 
-    def _units_in(self, compose_path: Path, data: dict) -> list[Unit]:
+    def _units_in(self, compose_path: Path, data: dict[str, Any]) -> list[Unit]:
         stack_dir = _norm(str(compose_path.parent.relative_to(self._root)))
         found = []
         for name, svc in (data.get("services") or {}).items():
@@ -163,7 +164,7 @@ class UnitCatalog:
             )
         return found
 
-    def matrix(self, changed_files: list[str]) -> list[dict]:
+    def matrix(self, changed_files: list[str]) -> list[dict[str, str | None]]:
         """The deduped build matrix (one entry per image) for a set of changed files."""
         units = self.units()
         selected = units if tooling_changed(changed_files) else affected_units(changed_files, units)

--- a/tools/ci/ci/apptests.py
+++ b/tools/ci/ci/apptests.py
@@ -23,10 +23,13 @@ single call rather than a place where behaviour accumulates.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from ci.affected import UnitCatalog
-from ci.ports import CommandRunner, Console, FileSystem
+from ci.ports import CommandRunner, FileSystem
+
+log = logging.getLogger(__name__)
 
 TIERS = ("unit", "integration", "e2e")
 # Directories holding code that is not ours; a manifest inside one is not a project.
@@ -70,12 +73,10 @@ class AppSuites:
         self,
         filesystem: FileSystem,
         commands: CommandRunner,
-        console: Console,
         repo_root: str | Path = ".",
     ) -> None:
         self._fs = filesystem
         self._commands = commands
-        self._console = console
         self._root = Path(repo_root)
 
     def projects_with(self, manifest: str) -> list[str]:
@@ -126,7 +127,7 @@ class AppSuites:
             if not present:
                 continue
             ran_any = True
-            self._console.out(f"==> {rel} : {' '.join(present)}")
+            log.info("==> %s : %s", rel, " ".join(present))
             paths = [f"tests/{t}" for t in present]
             extra = [] if gated else ["-o", "addopts="]
             if not self._commands.run(["uv", "run", "pytest", *paths, *extra], cwd=proj).ok:
@@ -146,7 +147,7 @@ class AppSuites:
             if script not in self._scripts(proj / "package.json"):
                 continue
             ran_any = True
-            self._console.out(f"==> {rel} : npm run {script}")
+            log.info("==> %s : npm run %s", rel, script)
             if not self._commands.run(["npm", "ci"], cwd=proj).ok:
                 rc = 1
                 continue
@@ -168,13 +169,11 @@ class SuiteRunner:
         suites: AppSuites,
         catalog: UnitCatalog,
         commands: CommandRunner,
-        console: Console,
         repo_root: str | Path = ".",
     ) -> None:
         self._suites = suites
         self._catalog = catalog
         self._commands = commands
-        self._console = console
         self._root = str(repo_root)
 
     def changed_files(self, base: str) -> list[str]:
@@ -214,5 +213,5 @@ class SuiteRunner:
         )
         js_rc, js_ran = self._suites.run_js(pick(self._suites.js_projects()), tier)
         if not (py_ran or js_ran):
-            self._console.out("No matching test suites.")
+            log.info("No matching test suites.")
         return py_rc or js_rc

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -37,7 +37,6 @@ from ci.containers import Container
 from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
-from ci.ports import Output
 from ci.stackgraph import DependencyCheck
 
 
@@ -45,10 +44,9 @@ from ci.stackgraph import DependencyCheck
 def _cmd_affected(
     args: argparse.Namespace,
     catalog: UnitCatalog = Provide[Container.catalog],
-    output: Output = Provide[Container.output],
 ) -> int:
     changed = args.files or [line.strip() for line in sys.stdin if line.strip()]
-    output.line(json.dumps(catalog.matrix(changed)))
+    print(json.dumps(catalog.matrix(changed)))
     return 0
 
 
@@ -65,12 +63,11 @@ def _cmd_projects(
     args: argparse.Namespace,
     suites: AppSuites = Provide[Container.suites],
     suite_runner: SuiteRunner = Provide[Container.suite_runner],
-    output: Output = Provide[Container.output],
 ) -> int:
     changed = args.files or [line.strip() for line in sys.stdin if line.strip()]
     affected = set(suite_runner.affected_projects(suites.python_projects(), changed))
     affected |= set(suite_runner.affected_projects(suites.js_projects(), changed))
-    output.line(json.dumps([{"project": p} for p in sorted(affected)]))
+    print(json.dumps([{"project": p} for p in sorted(affected)]))
     return 0
 
 
@@ -78,10 +75,9 @@ def _cmd_projects(
 def _cmd_images(
     args: argparse.Namespace,
     catalog: UnitCatalog = Provide[Container.catalog],
-    output: Output = Provide[Container.output],
 ) -> int:
     for image in catalog.image_names():
-        output.line(image)
+        print(image)
     return 0
 
 

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 
@@ -36,7 +37,7 @@ from ci.containers import Container
 from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
-from ci.ports import Console
+from ci.ports import Output
 from ci.stackgraph import DependencyCheck
 
 
@@ -44,10 +45,10 @@ from ci.stackgraph import DependencyCheck
 def _cmd_affected(
     args: argparse.Namespace,
     catalog: UnitCatalog = Provide[Container.catalog],
-    console: Console = Provide[Container.console],
+    output: Output = Provide[Container.output],
 ) -> int:
     changed = args.files or [line.strip() for line in sys.stdin if line.strip()]
-    console.out(json.dumps(catalog.matrix(changed)))
+    output.line(json.dumps(catalog.matrix(changed)))
     return 0
 
 
@@ -64,12 +65,12 @@ def _cmd_projects(
     args: argparse.Namespace,
     suites: AppSuites = Provide[Container.suites],
     suite_runner: SuiteRunner = Provide[Container.suite_runner],
-    console: Console = Provide[Container.console],
+    output: Output = Provide[Container.output],
 ) -> int:
     changed = args.files or [line.strip() for line in sys.stdin if line.strip()]
     affected = set(suite_runner.affected_projects(suites.python_projects(), changed))
     affected |= set(suite_runner.affected_projects(suites.js_projects(), changed))
-    console.out(json.dumps([{"project": p} for p in sorted(affected)]))
+    output.line(json.dumps([{"project": p} for p in sorted(affected)]))
     return 0
 
 
@@ -77,10 +78,10 @@ def _cmd_projects(
 def _cmd_images(
     args: argparse.Namespace,
     catalog: UnitCatalog = Provide[Container.catalog],
-    console: Console = Provide[Container.console],
+    output: Output = Provide[Container.output],
 ) -> int:
     for image in catalog.image_names():
-        console.out(image)
+        output.line(image)
     return 0
 
 
@@ -189,6 +190,9 @@ def build_container(args: argparse.Namespace, process_env: dict[str, str] | None
 
 
 def main() -> None:
+    # Diagnostics go to stderr through logging; stdout carries only the payload,
+    # which callers pipe and parse.
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
     args = build_parser().parse_args()
     build_container(args)
     raise SystemExit(args.func(args))

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -1,15 +1,18 @@
 """The ``ci`` command — one CLI surface for the repo's build/test tooling.
 
 Subcommands:
-  ci affected [REPO_ROOT] [FILE ...]   print the affected build matrix as JSON
-                                       (files default to stdin, newline-separated)
+  ci affected [FILE ...]                print the affected build matrix as JSON
+                                        (files default to stdin, newline-separated)
+  ci projects [FILE ...]                print the test projects a change affects, as JSON
   ci test [SELECTOR] [--tier T] [--affected]   run app pytest suites by tier
-  ci images [REPO_ROOT]                 list every buildable image name (one per line)
+  ci images                             list every buildable image name (one per line)
   ci gc [--apply] [--cutoff-days N]     prune stale :sha/untagged ghcr versions (dry-run by default)
   ci idempotence PLAYBOOK [ANSIBLE ARGS] run a playbook twice; fail unless the second changes nothing
   ci deploy [STACK ...] --plan          print the deploy plan and live state; deploy nothing
-  ci check-deps [REPO_ROOT]             the x-homelab declarations resolve, and are complete
-  ci projects [REPO_ROOT] [FILE ...]    print the test projects a change affects, as JSON
+  ci check-deps                         the x-homelab declarations resolve, and are complete
+
+Every subcommand takes ``--repo-root`` (default ``.``); nothing takes it
+positionally, so a positional argument always means the same thing.
 
 Each handler is one call into an injected service — behaviour lives in the
 services, not here — so tests drive them through the container with fakes
@@ -23,6 +26,7 @@ import json
 import os
 import sys
 
+from dependency_injector import providers
 from dependency_injector.wiring import Provide, inject
 
 from ci.affected import UnitCatalog
@@ -33,7 +37,7 @@ from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
 from ci.ports import Console
-from ci.stackgraph import DependencyGraph, UnresolvedGraph
+from ci.stackgraph import DependencyCheck
 
 
 @inject
@@ -108,22 +112,9 @@ def _cmd_deploy(
 @inject
 def _cmd_check_deps(
     args: argparse.Namespace,
-    graph: DependencyGraph = Provide[Container.graph],
-    console: Console = Provide[Container.console],
+    dependency_check: DependencyCheck = Provide[Container.dependency_check],
 ) -> int:
-    try:
-        stacks = graph.stacks()
-        graph.resolve()
-    except UnresolvedGraph as exc:
-        console.out(f"✗ {exc}")
-        return 1
-    if missing := graph.undeclared():
-        console.out("✗ dependencies visible in the compose file but not declared in x-homelab.requires:")
-        for stack, requires in sorted(missing.items()):
-            console.out(f"    {stack}: {', '.join(sorted(requires))}")
-        return 1
-    console.out(f"✓ {len(stacks)} stacks resolve, with every dependency they reveal declared")
-    return 0
+    return dependency_check.report()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -131,8 +122,8 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     aff = sub.add_parser("affected", help="print the affected build matrix as JSON")
-    aff.add_argument("repo_root", nargs="?", default=".")
     aff.add_argument("files", nargs="*")
+    aff.add_argument("--repo-root", default=".")
     aff.set_defaults(func=_cmd_affected)
 
     test = sub.add_parser("test", help="run app pytest suites by tier")
@@ -144,18 +135,18 @@ def build_parser() -> argparse.ArgumentParser:
     test.set_defaults(func=_cmd_test)
 
     proj = sub.add_parser("projects", help="print the test projects a change affects, as JSON")
-    proj.add_argument("repo_root", nargs="?", default=".")
     proj.add_argument("files", nargs="*")
+    proj.add_argument("--repo-root", default=".")
     proj.set_defaults(func=_cmd_projects)
 
     images = sub.add_parser("images", help="list every buildable image name (one per line)")
-    images.add_argument("repo_root", nargs="?", default=".")
+    images.add_argument("--repo-root", default=".")
     images.set_defaults(func=_cmd_images)
 
     gc_p = sub.add_parser("gc", help="prune stale :sha/untagged ghcr versions (dry-run by default)")
-    gc_p.add_argument("repo_root", nargs="?", default=".")
     gc_p.add_argument("--cutoff-days", type=int, default=14)
     gc_p.add_argument("--apply", action="store_true", help="actually delete (default: dry-run)")
+    gc_p.add_argument("--repo-root", default=".")
     gc_p.set_defaults(func=_cmd_gc)
 
     idem = sub.add_parser("idempotence", help="run a playbook twice; the second must change nothing")
@@ -175,18 +166,23 @@ def build_parser() -> argparse.ArgumentParser:
     dep.set_defaults(func=_cmd_deploy)
 
     deps = sub.add_parser("check-deps", help="the x-homelab declarations resolve, and are complete")
-    deps.add_argument("repo_root", nargs="?", default=".")
+    deps.add_argument("--repo-root", default=".")
     deps.set_defaults(func=_cmd_check_deps)
     return parser
 
 
 def build_container(args: argparse.Namespace, process_env: dict[str, str] | None = None) -> Container:
     """Wire the container for one invocation: this run's repo root and environment."""
-    repo_root = getattr(args, "repo_root", ".") or "."
     container = Container()
-    container.config.repo_root.from_value(repo_root)
-    container.config.env.from_value(
-        load_env(container.filesystem(), repo_root, dict(os.environ if process_env is None else process_env))
+    container.repo_root.override(providers.Object(args.repo_root))
+    container.env.override(
+        providers.Object(
+            load_env(
+                container.filesystem(),
+                args.repo_root,
+                dict(os.environ if process_env is None else process_env),
+            )
+        )
     )
     container.wire(modules=[__name__])
     return container

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -34,7 +34,7 @@ from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
 from ci.config import load_env
 from ci.containers import Container
-from ci.deploy import DeployPlan
+from ci.deploy import DeployPlanner
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
 from ci.stackgraph import DependencyGraph, check_dependencies
@@ -101,9 +101,9 @@ def _cmd_idempotence(
 @inject
 def _cmd_deploy(
     args: argparse.Namespace,
-    deploy_plan: DeployPlan = Provide[Container.deploy_plan],
+    planner: DeployPlanner = Provide[Container.planner],
 ) -> int:
-    return deploy_plan.report(args.stacks or None)
+    return planner.report(args.stacks or None)
 
 
 @inject

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -7,7 +7,7 @@ Subcommands:
   ci images [REPO_ROOT]                 list every buildable image name (one per line)
   ci gc [--apply] [--cutoff-days N]     prune stale :sha/untagged ghcr versions (dry-run by default)
   ci idempotence PLAYBOOK [ANSIBLE ARGS] run a playbook twice; fail unless the second changes nothing
-  ci deploy [STACK ...] --plan          print the resolved deploy order; deploy nothing
+  ci deploy [STACK ...] --plan          print the deploy plan and live state; deploy nothing
   ci check-deps [REPO_ROOT]             the x-homelab declarations resolve, and are complete
   ci projects [REPO_ROOT] [FILE ...]    print the test projects a change affects, as JSON
 
@@ -29,6 +29,7 @@ from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
 from ci.config import load_env
 from ci.containers import Container
+from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
 from ci.ports import Console
@@ -99,18 +100,9 @@ def _cmd_idempotence(
 @inject
 def _cmd_deploy(
     args: argparse.Namespace,
-    graph: DependencyGraph = Provide[Container.graph],
-    console: Console = Provide[Container.console],
+    deploy_plan: DeployPlan = Provide[Container.deploy_plan],
 ) -> int:
-    try:
-        order = graph.resolve(args.stacks or None)
-    except UnresolvedGraph as exc:
-        console.err(f"✗ {exc}")
-        return 1
-    for stack in order:
-        console.out(stack)
-    console.err(f"\n{len(order)} stack(s) — plan only, nothing deployed.")
-    return 0
+    return deploy_plan.report(args.stacks or None)
 
 
 @inject
@@ -173,12 +165,12 @@ def build_parser() -> argparse.ArgumentParser:
                       help="passed through to ansible-playbook")
     idem.set_defaults(func=_cmd_idempotence)
 
-    dep = sub.add_parser("deploy", help="print the resolved deploy order (--plan is the only mode)")
+    dep = sub.add_parser("deploy", help="print the deploy plan and live state (--plan is the only mode)")
     dep.add_argument("stacks", nargs="*", help="deploy targets; omit for every stack")
     # Required until 1.3 gives `ci deploy` something to execute — refusing here
     # beats a flag that silently means nothing.
     dep.add_argument("--plan", action="store_true", required=True,
-                     help="print the order and deploy nothing")
+                     help="print the plan and deploy nothing")
     dep.add_argument("--repo-root", default=".")
     dep.set_defaults(func=_cmd_deploy)
 

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -37,7 +37,7 @@ from ci.containers import Container
 from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
-from ci.stackgraph import DependencyCheck
+from ci.stackgraph import DependencyGraph, check_dependencies
 
 
 @inject
@@ -109,9 +109,9 @@ def _cmd_deploy(
 @inject
 def _cmd_check_deps(
     args: argparse.Namespace,
-    dependency_check: DependencyCheck = Provide[Container.dependency_check],
+    graph: DependencyGraph = Provide[Container.graph],
 ) -> int:
-    return dependency_check.report()
+    return check_dependencies(graph)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tools/ci/ci/cli.py
+++ b/tools/ci/ci/cli.py
@@ -151,6 +151,10 @@ def build_parser() -> argparse.ArgumentParser:
     # REMAINDER so ansible's own flags (-i, --limit, --skip-tags) pass through unparsed.
     idem.add_argument("ansible_args", nargs=argparse.REMAINDER,
                       help="passed through to ansible-playbook")
+    # Unused by the check itself, but the composition root reads it off every
+    # subcommand's args. REMAINDER swallows everything after the playbook, so
+    # this one only takes effect before it: `ci idempotence --repo-root X play.yml`.
+    idem.add_argument("--repo-root", default=".")
     idem.set_defaults(func=_cmd_idempotence)
 
     dep = sub.add_parser("deploy", help="print the deploy plan and live state (--plan is the only mode)")

--- a/tools/ci/ci/cluster.py
+++ b/tools/ci/ci/cluster.py
@@ -1,0 +1,86 @@
+"""What the Swarm cluster currently holds, so a plan can say what will change.
+
+Two list commands answer it: `docker stack ls` names what exists, `docker
+service ls` gives each service its `running/desired` column. Nothing here
+writes — a plan that mutated the thing it is describing would be a lie.
+
+There is deliberately no readiness state. Swarm promotes a task to `running`
+only once its healthcheck passes, so convergence *is* health.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from enum import Enum
+
+from ci.ports import CommandRunner
+
+STACK_LS = ["docker", "stack", "ls", "--format", "{{.Name}}"]
+SERVICE_LS = ["docker", "service", "ls", "--format", "{{.Name}}\t{{.Replicas}}"]
+
+# Swarm's replicas column: `1/1`, or `1/1 (max 1 per node)` under a placement limit.
+REPLICAS = re.compile(r"^\s*(\d+)\s*/\s*(\d+)")
+
+
+class ClusterUnreachable(Exception):
+    """The cluster could not be read, so no state can be reported."""
+
+
+class StackState(Enum):
+    ABSENT = "absent"
+    PRESENT = "present"
+    CONVERGED = "converged"
+
+
+def parse_replicas(column: str) -> tuple[int, int]:
+    """Running and desired replicas. Anything unreadable is never converged."""
+    if match := REPLICAS.match(column):
+        return int(match.group(1)), int(match.group(2))
+    return -1, 0
+
+
+class SwarmCluster:
+    """The live state of every stack, read once per invocation."""
+
+    def __init__(self, commands: CommandRunner) -> None:
+        self._commands = commands
+        self._states: dict[str, StackState] | None = None
+
+    def state(self, stack: str) -> StackState:
+        return self.states().get(stack, StackState.ABSENT)
+
+    def states(self) -> dict[str, StackState]:
+        if self._states is None:
+            self._states = self._read()
+        return self._states
+
+    def _read(self) -> dict[str, StackState]:
+        deployed = self._lines(STACK_LS)
+        replicas: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for line in self._lines(SERVICE_LS):
+            name, _, column = line.partition("\t")
+            if owner := _owner(name, deployed):
+                replicas[owner].append(parse_replicas(column))
+        return {
+            stack: StackState.CONVERGED
+            if replicas[stack] and all(run == want for run, want in replicas[stack])
+            else StackState.PRESENT
+            for stack in deployed
+        }
+
+    def _lines(self, argv: list[str]) -> list[str]:
+        outcome = self._commands.run(argv, capture=True)
+        if not outcome.ok:
+            raise ClusterUnreachable(f"{' '.join(argv[:3])} failed: {outcome.stderr.strip()}")
+        return [line for line in outcome.stdout.splitlines() if line.strip()]
+
+
+def _owner(service: str, stacks: list[str]) -> str | None:
+    """The stack a service belongs to: the longest name it is prefixed with.
+
+    Stack names contain underscores (`actual_server`), so the prefix is only
+    unambiguous against the set the cluster actually reports.
+    """
+    candidates = [s for s in stacks if service.startswith(f"{s}_")]
+    return max(candidates, key=len) if candidates else None

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dependency_injector import containers, providers
 
-from ci.adapters import LocalFileSystem, StdoutConsole, Subprocess, SystemClock
+from ci.adapters import LocalFileSystem, StdoutOutput, Subprocess, SystemClock
 from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
 from ci.cluster import SwarmCluster
@@ -35,14 +35,13 @@ class Container(containers.DeclarativeContainer):
     filesystem = providers.Singleton(LocalFileSystem)
     commands = providers.Singleton(Subprocess)
     clock = providers.Singleton(SystemClock)
-    console = providers.Singleton(StdoutConsole)
+    output = providers.Singleton(StdoutOutput)
 
     catalog = providers.Factory(UnitCatalog, filesystem=filesystem, repo_root=repo_root)
     suites = providers.Factory(
         AppSuites,
         filesystem=filesystem,
         commands=commands,
-        console=console,
         repo_root=repo_root,
     )
     suite_runner = providers.Factory(
@@ -50,18 +49,17 @@ class Container(containers.DeclarativeContainer):
         suites=suites,
         catalog=catalog,
         commands=commands,
-        console=console,
         repo_root=repo_root,
     )
     registry_gc = providers.Factory(
-        RegistryGc, catalog=catalog, commands=commands, clock=clock, console=console
+        RegistryGc, catalog=catalog, commands=commands, clock=clock
     )
-    idempotence = providers.Factory(IdempotenceCheck, commands=commands, console=console)
+    idempotence = providers.Factory(IdempotenceCheck, commands=commands, output=output)
 
     stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=repo_root)
     graph = providers.Factory(DependencyGraph, tree=stack_tree, env=env)
-    dependency_check = providers.Factory(DependencyCheck, graph=graph, console=console)
+    dependency_check = providers.Factory(DependencyCheck, graph=graph)
     cluster = providers.Singleton(SwarmCluster, commands=commands)
     deploy_plan = providers.Factory(
-        DeployPlan, graph=graph, cluster=cluster, console=console
+        DeployPlan, graph=graph, cluster=cluster, output=output
     )

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -15,6 +15,8 @@ from dependency_injector import containers, providers
 from ci.adapters import LocalFileSystem, StdoutConsole, Subprocess, SystemClock
 from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
+from ci.cluster import SwarmCluster
+from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
 from ci.stackgraph import DependencyGraph, StackTree
@@ -51,3 +53,7 @@ class Container(containers.DeclarativeContainer):
 
     stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=config.repo_root)
     graph = providers.Factory(DependencyGraph, tree=stack_tree, env=config.env)
+    cluster = providers.Factory(SwarmCluster, commands=commands)
+    deploy_plan = providers.Factory(
+        DeployPlan, graph=graph, cluster=cluster, console=console
+    )

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -25,7 +25,7 @@ from ci.cluster import SwarmCluster
 from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
-from ci.stackgraph import DependencyCheck, DependencyGraph, StackTree
+from ci.stackgraph import DependencyGraph, StackTree
 
 
 class Container(containers.DeclarativeContainer):
@@ -57,6 +57,5 @@ class Container(containers.DeclarativeContainer):
 
     stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=repo_root)
     graph = providers.Factory(DependencyGraph, tree=stack_tree, env=env)
-    dependency_check = providers.Factory(DependencyCheck, graph=graph)
     cluster = providers.Singleton(SwarmCluster, commands=commands)
     deploy_plan = providers.Factory(DeployPlan, graph=graph, cluster=cluster)

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -22,7 +22,7 @@ from ci.adapters import LocalFileSystem, Subprocess, SystemClock
 from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
 from ci.cluster import SwarmCluster
-from ci.deploy import DeployPlan
+from ci.deploy import DeployPlanner
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
 from ci.stackgraph import DependencyGraph, StackTree
@@ -58,4 +58,4 @@ class Container(containers.DeclarativeContainer):
     stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=repo_root)
     graph = providers.Factory(DependencyGraph, tree=stack_tree, env=env)
     cluster = providers.Singleton(SwarmCluster, commands=commands)
-    deploy_plan = providers.Factory(DeployPlan, graph=graph, cluster=cluster)
+    planner = providers.Factory(DeployPlanner, graph=graph, cluster=cluster)

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dependency_injector import containers, providers
 
-from ci.adapters import LocalFileSystem, StdoutOutput, Subprocess, SystemClock
+from ci.adapters import LocalFileSystem, Subprocess, SystemClock
 from ci.affected import UnitCatalog
 from ci.apptests import AppSuites, SuiteRunner
 from ci.cluster import SwarmCluster
@@ -35,7 +35,6 @@ class Container(containers.DeclarativeContainer):
     filesystem = providers.Singleton(LocalFileSystem)
     commands = providers.Singleton(Subprocess)
     clock = providers.Singleton(SystemClock)
-    output = providers.Singleton(StdoutOutput)
 
     catalog = providers.Factory(UnitCatalog, filesystem=filesystem, repo_root=repo_root)
     suites = providers.Factory(
@@ -54,12 +53,10 @@ class Container(containers.DeclarativeContainer):
     registry_gc = providers.Factory(
         RegistryGc, catalog=catalog, commands=commands, clock=clock
     )
-    idempotence = providers.Factory(IdempotenceCheck, commands=commands, output=output)
+    idempotence = providers.Factory(IdempotenceCheck, commands=commands)
 
     stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=repo_root)
     graph = providers.Factory(DependencyGraph, tree=stack_tree, env=env)
     dependency_check = providers.Factory(DependencyCheck, graph=graph)
     cluster = providers.Singleton(SwarmCluster, commands=commands)
-    deploy_plan = providers.Factory(
-        DeployPlan, graph=graph, cluster=cluster, output=output
-    )
+    deploy_plan = providers.Factory(DeployPlan, graph=graph, cluster=cluster)

--- a/tools/ci/ci/containers.py
+++ b/tools/ci/ci/containers.py
@@ -1,11 +1,17 @@
 """The composition root.
 
-Adapters are singletons — they hold no state worth rebuilding. Services are
-factories because they close over configuration the CLI sets from its arguments.
+Adapters are singletons — they hold no state worth rebuilding, and so is
+:class:`SwarmCluster`, whose whole contract is reading the cluster once per
+invocation. Services are factories because they close over configuration the
+CLI sets from its arguments.
 
-``config`` carries everything read from outside the process: the repo root and
-the merged environment. Tests build a Container and override a provider with a
-fake, which is the whole reason the ports exist.
+``repo_root`` and ``env`` are everything read from outside the process, declared
+as :class:`providers.Dependency` rather than a ``Configuration`` provider: they
+are two typed values, not a config file, and a container told neither raises
+instead of resolving to a default that would read the wrong tree.
+
+Tests build a Container and override a provider with a fake, which is the whole
+reason the ports exist.
 """
 
 from __future__ import annotations
@@ -19,24 +25,25 @@ from ci.cluster import SwarmCluster
 from ci.deploy import DeployPlan
 from ci.gc import RegistryGc
 from ci.idempotence import IdempotenceCheck
-from ci.stackgraph import DependencyGraph, StackTree
+from ci.stackgraph import DependencyCheck, DependencyGraph, StackTree
 
 
 class Container(containers.DeclarativeContainer):
-    config = providers.Configuration()
+    repo_root = providers.Dependency(instance_of=str)
+    env = providers.Dependency(instance_of=dict)
 
     filesystem = providers.Singleton(LocalFileSystem)
     commands = providers.Singleton(Subprocess)
     clock = providers.Singleton(SystemClock)
     console = providers.Singleton(StdoutConsole)
 
-    catalog = providers.Factory(UnitCatalog, filesystem=filesystem, repo_root=config.repo_root)
+    catalog = providers.Factory(UnitCatalog, filesystem=filesystem, repo_root=repo_root)
     suites = providers.Factory(
         AppSuites,
         filesystem=filesystem,
         commands=commands,
         console=console,
-        repo_root=config.repo_root,
+        repo_root=repo_root,
     )
     suite_runner = providers.Factory(
         SuiteRunner,
@@ -44,16 +51,17 @@ class Container(containers.DeclarativeContainer):
         catalog=catalog,
         commands=commands,
         console=console,
-        repo_root=config.repo_root,
+        repo_root=repo_root,
     )
     registry_gc = providers.Factory(
         RegistryGc, catalog=catalog, commands=commands, clock=clock, console=console
     )
     idempotence = providers.Factory(IdempotenceCheck, commands=commands, console=console)
 
-    stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=config.repo_root)
-    graph = providers.Factory(DependencyGraph, tree=stack_tree, env=config.env)
-    cluster = providers.Factory(SwarmCluster, commands=commands)
+    stack_tree = providers.Factory(StackTree, filesystem=filesystem, repo_root=repo_root)
+    graph = providers.Factory(DependencyGraph, tree=stack_tree, env=env)
+    dependency_check = providers.Factory(DependencyCheck, graph=graph, console=console)
+    cluster = providers.Singleton(SwarmCluster, commands=commands)
     deploy_plan = providers.Factory(
         DeployPlan, graph=graph, cluster=cluster, console=console
     )

--- a/tools/ci/ci/deploy.py
+++ b/tools/ci/ci/deploy.py
@@ -15,7 +15,6 @@ import logging
 from dataclasses import dataclass
 
 from ci.cluster import ClusterUnreachable, StackState, SwarmCluster
-from ci.ports import Output
 from ci.stackgraph import DependencyGraph, UnresolvedGraph
 
 log = logging.getLogger(__name__)
@@ -32,10 +31,9 @@ class PlanRow:
 
 
 class DeployPlan:
-    def __init__(self, graph: DependencyGraph, cluster: SwarmCluster, output: Output) -> None:
+    def __init__(self, graph: DependencyGraph, cluster: SwarmCluster) -> None:
         self._graph = graph
         self._cluster = cluster
-        self._output = output
 
     def rows(self, targets: list[str] | None = None) -> list[PlanRow]:
         order = self._graph.resolve(targets)
@@ -63,7 +61,7 @@ class DeployPlan:
             log.error("✗ %s", exc)
             return 1
         for line in _render(rows):
-            self._output.line(line)
+            print(line)
         log.info("%d stack(s) — plan only, nothing deployed.", len(rows))
         return 0
 

--- a/tools/ci/ci/deploy.py
+++ b/tools/ci/ci/deploy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from enum import Enum
 
 from ci.cluster import ClusterUnreachable, StackState, SwarmCluster
 from ci.stackgraph import DependencyGraph, UnresolvedGraph
@@ -20,14 +21,30 @@ from ci.stackgraph import DependencyGraph, UnresolvedGraph
 log = logging.getLogger(__name__)
 
 
+class Origin(Enum):
+    """How a stack got into the plan."""
+
+    TARGET = "target"  # named on the command line
+    DEPENDENCY = "dependency"  # pulled in behind a target
+    WHOLE_TREE = "whole-tree"  # no targets named, so the plan is everything
+
+    @property
+    def verb(self) -> str:
+        return "ensure" if self is Origin.DEPENDENCY else "deploy"
+
+
 @dataclass(frozen=True)
 class PlanRow:
-    """One stack in the plan: how it got there, and what it is right now."""
+    """One stack in the plan: how it got there, and what it is right now.
 
-    verb: str
+    Holds no display text. `required_by` is the stacks themselves, so a caller
+    can act on them; turning that into a column is :func:`_render`'s job.
+    """
+
     stack: str
     state: StackState
-    reason: str
+    origin: Origin
+    required_by: tuple[str, ...] = ()
 
 
 class DeployPlan:
@@ -43,14 +60,15 @@ class DeployPlan:
         named = set(targets or ())
         rows = []
         for stack in order:
+            requiring: tuple[str, ...] = ()
             if not targets:
-                verb, reason = "deploy", ""
+                origin = Origin.WHOLE_TREE
             elif stack in named:
-                verb, reason = "deploy", "explicit target"
+                origin = Origin.TARGET
             else:
-                verb = "ensure"
-                reason = f"required by {', '.join(pulled_in.get(stack, []))}"
-            rows.append(PlanRow(verb, stack, self._cluster.state(stack), reason))
+                origin = Origin.DEPENDENCY
+                requiring = tuple(pulled_in.get(stack, []))
+            rows.append(PlanRow(stack, self._cluster.state(stack), origin, requiring))
         return rows
 
     def report(self, targets: list[str] | None = None) -> int:
@@ -66,13 +84,22 @@ class DeployPlan:
         return 0
 
 
+def _reason(row: PlanRow) -> str:
+    """Why the row is in the plan, as the column reads it."""
+    if row.origin is Origin.DEPENDENCY:
+        return f"required by {', '.join(row.required_by)}"
+    if row.origin is Origin.TARGET:
+        return "explicit target"
+    return ""
+
+
 def _render(rows: list[PlanRow]) -> list[str]:
     """Aligned columns, so the states can be scanned down rather than read."""
-    verb = max((len(r.verb) for r in rows), default=0)
+    verb = max((len(r.origin.verb) for r in rows), default=0)
     stack = max((len(r.stack) for r in rows), default=0)
     state = max((len(r.state.value) for r in rows), default=0)
     return [
-        f"  {r.verb:<{verb}}   {r.stack:<{stack}}   {r.state.value:<{state}}"
-        + (f"   → {r.reason}" if r.reason else "")
+        f"  {r.origin.verb:<{verb}}   {r.stack:<{stack}}   {r.state.value:<{state}}"
+        + (f"   → {reason}" if (reason := _reason(r)) else "")
         for r in rows
     ]

--- a/tools/ci/ci/deploy.py
+++ b/tools/ci/ci/deploy.py
@@ -47,7 +47,7 @@ class PlanRow:
     required_by: tuple[str, ...] = ()
 
 
-class DeployPlan:
+class DeployPlanner:
     def __init__(self, graph: DependencyGraph, cluster: SwarmCluster) -> None:
         self._graph = graph
         self._cluster = cluster

--- a/tools/ci/ci/deploy.py
+++ b/tools/ci/ci/deploy.py
@@ -11,11 +11,14 @@ stack that was named, `ensure` for one pulled in behind it.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from ci.cluster import ClusterUnreachable, StackState, SwarmCluster
-from ci.ports import Console
+from ci.ports import Output
 from ci.stackgraph import DependencyGraph, UnresolvedGraph
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -29,10 +32,10 @@ class PlanRow:
 
 
 class DeployPlan:
-    def __init__(self, graph: DependencyGraph, cluster: SwarmCluster, console: Console) -> None:
+    def __init__(self, graph: DependencyGraph, cluster: SwarmCluster, output: Output) -> None:
         self._graph = graph
         self._cluster = cluster
-        self._console = console
+        self._output = output
 
     def rows(self, targets: list[str] | None = None) -> list[PlanRow]:
         order = self._graph.resolve(targets)
@@ -57,11 +60,11 @@ class DeployPlan:
         try:
             rows = self.rows(targets)
         except (UnresolvedGraph, ClusterUnreachable) as exc:
-            self._console.err(f"✗ {exc}")
+            log.error("✗ %s", exc)
             return 1
         for line in _render(rows):
-            self._console.out(line)
-        self._console.err(f"\n{len(rows)} stack(s) — plan only, nothing deployed.")
+            self._output.line(line)
+        log.info("%d stack(s) — plan only, nothing deployed.", len(rows))
         return 0
 
 

--- a/tools/ci/ci/deploy.py
+++ b/tools/ci/ci/deploy.py
@@ -1,0 +1,77 @@
+"""The deploy plan: resolved order, live state, and why each stack is in it.
+
+`ci deploy --plan` exists to show what a deploy *would change*, not to list the
+whole tree. That takes two things this module joins — the order the
+declarations imply (:mod:`ci.stackgraph`) and what the cluster already holds
+(:mod:`ci.cluster`).
+
+Nothing here deploys. The verbs are how a row got into the plan: `deploy` for a
+stack that was named, `ensure` for one pulled in behind it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ci.cluster import ClusterUnreachable, StackState, SwarmCluster
+from ci.ports import Console
+from ci.stackgraph import DependencyGraph, UnresolvedGraph
+
+
+@dataclass(frozen=True)
+class PlanRow:
+    """One stack in the plan: how it got there, and what it is right now."""
+
+    verb: str
+    stack: str
+    state: StackState
+    reason: str
+
+
+class DeployPlan:
+    def __init__(self, graph: DependencyGraph, cluster: SwarmCluster, console: Console) -> None:
+        self._graph = graph
+        self._cluster = cluster
+        self._console = console
+
+    def rows(self, targets: list[str] | None = None) -> list[PlanRow]:
+        order = self._graph.resolve(targets)
+        # A full plan has no target to attribute anything to: everything in it
+        # was asked for.
+        pulled_in = self._graph.required_by(targets) if targets else {}
+        named = set(targets or ())
+        rows = []
+        for stack in order:
+            if not targets:
+                verb, reason = "deploy", ""
+            elif stack in named:
+                verb, reason = "deploy", "explicit target"
+            else:
+                verb = "ensure"
+                reason = f"required by {', '.join(pulled_in.get(stack, []))}"
+            rows.append(PlanRow(verb, stack, self._cluster.state(stack), reason))
+        return rows
+
+    def report(self, targets: list[str] | None = None) -> int:
+        """Print the plan. Reads the cluster, changes nothing, exits 1 on failure."""
+        try:
+            rows = self.rows(targets)
+        except (UnresolvedGraph, ClusterUnreachable) as exc:
+            self._console.err(f"✗ {exc}")
+            return 1
+        for line in _render(rows):
+            self._console.out(line)
+        self._console.err(f"\n{len(rows)} stack(s) — plan only, nothing deployed.")
+        return 0
+
+
+def _render(rows: list[PlanRow]) -> list[str]:
+    """Aligned columns, so the states can be scanned down rather than read."""
+    verb = max((len(r.verb) for r in rows), default=0)
+    stack = max((len(r.stack) for r in rows), default=0)
+    state = max((len(r.state.value) for r in rows), default=0)
+    return [
+        f"  {r.verb:<{verb}}   {r.stack:<{stack}}   {r.state.value:<{state}}"
+        + (f"   → {r.reason}" if r.reason else "")
+        for r in rows
+    ]

--- a/tools/ci/ci/gc.py
+++ b/tools/ci/ci/gc.py
@@ -11,12 +11,15 @@ command runner, so its tests fix "now" and assert on the gh calls it would make.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime
 from typing import Any
 
 from ci.affected import UnitCatalog
-from ci.ports import Clock, CommandRunner, Console
+from ci.ports import Clock, CommandRunner
+
+log = logging.getLogger(__name__)
 
 # One ghcr package version as `gh api` returns it: id, created_at, and metadata.tags.
 Version = dict[str, Any]
@@ -55,12 +58,10 @@ class RegistryGc:
         catalog: UnitCatalog,
         commands: CommandRunner,
         clock: Clock,
-        console: Console,
     ) -> None:
         self._catalog = catalog
         self._commands = commands
         self._clock = clock
-        self._console = console
 
     def prune(self, cutoff_days: int = 14, apply: bool = False) -> int:
         """Dry-run by default. Uses the local ``gh`` CLI auth (read+delete:packages).
@@ -81,10 +82,10 @@ class RegistryGc:
                          f"/user/packages/container/{image}/versions/{vid}"],
                         check=True,
                     )
-                    self._console.out(f"{image}: deleted version {vid}")
+                    log.info("%s: deleted version %s", image, vid)
                 else:
-                    self._console.out(f"{image}: [dry-run] would delete version {vid}")
-        self._console.out(f"{'Pruned' if apply else 'Would prune'} {total} version(s).")
+                    log.info("%s: [dry-run] would delete version %s", image, vid)
+        log.info("%s %d version(s).", "Pruned" if apply else "Would prune", total)
         return total
 
     def _gh_json(self, args: list[str]) -> list[Version]:

--- a/tools/ci/ci/gc.py
+++ b/tools/ci/ci/gc.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime
+from typing import Any
 
-from ci.ports import Clock, CommandRunner, Console
 from ci.affected import UnitCatalog
+from ci.ports import Clock, CommandRunner, Console
+
+# One ghcr package version as `gh api` returns it: id, created_at, and metadata.tags.
+Version = dict[str, Any]
 
 _SEMVER = re.compile(r"^\d+\.\d+\.\d+")
 _KEEP_TAGS = {"latest", "main"}
@@ -26,14 +30,14 @@ def _is_release(tags: list[str]) -> bool:
     return any(t in _KEEP_TAGS or _SEMVER.match(t) for t in tags)
 
 
-def _created_ts(version: dict) -> float:
+def _created_ts(version: Version) -> float:
     return datetime.fromisoformat(version["created_at"].replace("Z", "+00:00")).timestamp()
 
 
-def versions_to_prune(versions: list[dict], now_ts: float, cutoff_days: int = 14) -> list:
+def versions_to_prune(versions: list[Version], now_ts: float, cutoff_days: int = 14) -> list[str]:
     """IDs of versions to delete: not a release/moving tag, and older than the cutoff."""
     cutoff = now_ts - cutoff_days * 86400
-    prune = []
+    prune: list[str] = []
     for v in versions:
         tags = (v.get("metadata", {}).get("container", {}) or {}).get("tags") or []
         if _is_release(tags):
@@ -83,6 +87,7 @@ class RegistryGc:
         self._console.out(f"{'Pruned' if apply else 'Would prune'} {total} version(s).")
         return total
 
-    def _gh_json(self, args: list[str]) -> list:
+    def _gh_json(self, args: list[str]) -> list[Version]:
         result = self._commands.run(["gh", "api", *args], capture=True, check=True)
-        return json.loads(result.stdout or "[]")
+        parsed: list[Version] = json.loads(result.stdout or "[]")
+        return parsed

--- a/tools/ci/ci/idempotence.py
+++ b/tools/ci/ci/idempotence.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 
-from ci.ports import CommandRunner, Output
+from ci.ports import CommandRunner
 
 log = logging.getLogger(__name__)
 
@@ -62,17 +63,16 @@ def violations(recap: dict[str, dict[str, int]]) -> dict[str, str]:
 class IdempotenceCheck:
     """Runs a playbook twice; the second run must report no change."""
 
-    def __init__(self, commands: CommandRunner, output: Output) -> None:
+    def __init__(self, commands: CommandRunner) -> None:
         self._commands = commands
-        self._output = output
 
     def verify(self, playbook: str, ansible_args: list[str] | None = None) -> int:
         cmd = ["ansible-playbook", playbook, *(ansible_args or [])]
         for run in (1, 2):
             log.info("=== idempotence: run %d/2 — %s", run, " ".join(cmd))
             result = self._commands.run(cmd, capture=True)
-            self._output.raw(result.stdout)
-            self._output.raw_err(result.stderr)
+            sys.stdout.write(result.stdout)
+            sys.stderr.write(result.stderr)
 
             if run == 1:
                 if not result.ok:

--- a/tools/ci/ci/idempotence.py
+++ b/tools/ci/ci/idempotence.py
@@ -7,9 +7,12 @@ runner, so its tests drive both runs without invoking ansible.
 
 from __future__ import annotations
 
+import logging
 import re
 
-from ci.ports import CommandRunner, Console
+from ci.ports import CommandRunner, Output
+
+log = logging.getLogger(__name__)
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _HOST_LINE = re.compile(r"^(?P<host>\S+)\s*:\s+(?P<counters>(?:\w+=\d+\s*)+)$")
@@ -59,22 +62,22 @@ def violations(recap: dict[str, dict[str, int]]) -> dict[str, str]:
 class IdempotenceCheck:
     """Runs a playbook twice; the second run must report no change."""
 
-    def __init__(self, commands: CommandRunner, console: Console) -> None:
+    def __init__(self, commands: CommandRunner, output: Output) -> None:
         self._commands = commands
-        self._console = console
+        self._output = output
 
     def verify(self, playbook: str, ansible_args: list[str] | None = None) -> int:
         cmd = ["ansible-playbook", playbook, *(ansible_args or [])]
         for run in (1, 2):
-            self._console.out(f"\n=== idempotence: run {run}/2 — {' '.join(cmd)}\n")
+            log.info("=== idempotence: run %d/2 — %s", run, " ".join(cmd))
             result = self._commands.run(cmd, capture=True)
-            self._console.write(result.stdout)
-            self._console.err(result.stderr.rstrip("\n"))
+            self._output.raw(result.stdout)
+            self._output.raw_err(result.stderr)
 
             if run == 1:
                 if not result.ok:
-                    self._console.out(
-                        f"\n✗ first run failed (rc={result.returncode}) — nothing to compare"
+                    log.error(
+                        "✗ first run failed (rc=%d) — nothing to compare", result.returncode
                     )
                     return result.returncode
                 continue
@@ -82,12 +85,12 @@ class IdempotenceCheck:
             try:
                 recap = parse_recap(result.stdout)
             except ValueError as exc:
-                self._console.out(f"\n✗ {exc}")
+                log.error("✗ %s", exc)
                 return 1
             if bad := violations(recap):
-                self._console.out("\n✗ second run was not a no-op:")
+                log.error("✗ second run was not a no-op:")
                 for host, why in sorted(bad.items()):
-                    self._console.out(f"    {host}: {why}")
+                    log.error("    %s: %s", host, why)
                 return 1
-            self._console.out(f"\n✓ second run reported no change on {len(recap)} host(s)")
+            log.info("✓ second run reported no change on %d host(s)", len(recap))
         return 0

--- a/tools/ci/ci/ports.py
+++ b/tools/ci/ci/ports.py
@@ -54,26 +54,3 @@ class Clock(Protocol):
     """Wall-clock time, so anything with a cutoff can be tested at a fixed instant."""
 
     def now_timestamp(self) -> float: ...
-
-
-@runtime_checkable
-class Output(Protocol):
-    """The program's answer on stdout.
-
-    Only for output a caller consumes: JSON a workflow parses, an image list a
-    shell loops over, the plan rows, and a subprocess's own streams passed
-    through untouched. Diagnostics are not this — services log those, so they
-    reach stderr without being mistaken for the payload.
-    """
-
-    def line(self, text: str = "") -> None:
-        """One line of payload on stdout."""
-        ...
-
-    def raw(self, text: str) -> None:
-        """Payload written to stdout exactly as given — no newline added."""
-        ...
-
-    def raw_err(self, text: str) -> None:
-        """A subprocess's own stderr, passed through unchanged."""
-        ...

--- a/tools/ci/ci/ports.py
+++ b/tools/ci/ci/ports.py
@@ -57,13 +57,23 @@ class Clock(Protocol):
 
 
 @runtime_checkable
-class Console(Protocol):
-    """Process output."""
+class Output(Protocol):
+    """The program's answer on stdout.
 
-    def out(self, message: str = "") -> None: ...
+    Only for output a caller consumes: JSON a workflow parses, an image list a
+    shell loops over, the plan rows, and a subprocess's own streams passed
+    through untouched. Diagnostics are not this — services log those, so they
+    reach stderr without being mistaken for the payload.
+    """
 
-    def err(self, message: str = "") -> None: ...
+    def line(self, text: str = "") -> None:
+        """One line of payload on stdout."""
+        ...
 
-    def write(self, text: str) -> None:
-        """Emit text exactly as given — no trailing newline added."""
+    def raw(self, text: str) -> None:
+        """Payload written to stdout exactly as given — no newline added."""
+        ...
+
+    def raw_err(self, text: str) -> None:
+        """A subprocess's own stderr, passed through unchanged."""
         ...

--- a/tools/ci/ci/stackgraph.py
+++ b/tools/ci/ci/stackgraph.py
@@ -4,7 +4,8 @@ Deploy order was the output of ``find``. It is now a topological sort of the
 declarations. :class:`StackTree` owns the filesystem; :class:`DependencyGraph`
 holds the logic and takes the tree, so its tests never touch disk.
 
-Nothing here deploys — it only decides what order a deploy would use.
+Nothing here deploys — it only decides what order a deploy would use, and
+:class:`DependencyCheck` reports whether the declarations hold up at all.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from pathlib import Path
 import yaml
 
 from ci.config import disabled_providers
-from ci.ports import FileSystem
+from ci.ports import Console, FileSystem
 
 # Stacks live one directory deep in each of these, alongside a docker-compose.yml.
 STACK_ROOTS = ("stacks", "stacks/apps")
@@ -141,6 +142,33 @@ class DependencyGraph:
     def required_by(self, targets: list[str]) -> dict[str, list[str]]:
         """For each stack a target pulls in, the targets that reach it."""
         return required_by(self.edges(), targets, sorted(self.disabled()))
+
+
+class DependencyCheck:
+    """The verdict `ci check-deps` prints: the declarations resolve, and are complete."""
+
+    def __init__(self, graph: DependencyGraph, console: Console) -> None:
+        self._graph = graph
+        self._console = console
+
+    def report(self) -> int:
+        try:
+            stacks = self._graph.stacks()
+            self._graph.resolve()
+        except UnresolvedGraph as exc:
+            self._console.out(f"✗ {exc}")
+            return 1
+        if missing := self._graph.undeclared():
+            self._console.out(
+                "✗ dependencies visible in the compose file but not declared in x-homelab.requires:"
+            )
+            for stack, requires in sorted(missing.items()):
+                self._console.out(f"    {stack}: {', '.join(sorted(requires))}")
+            return 1
+        self._console.out(
+            f"✓ {len(stacks)} stacks resolve, with every dependency they reveal declared"
+        )
+        return 0
 
 
 def required_by(

--- a/tools/ci/ci/stackgraph.py
+++ b/tools/ci/ci/stackgraph.py
@@ -60,13 +60,25 @@ class Stack:
 
 
 class StackTree:
-    """Reads the stacks out of the working tree, each compose file parsed once."""
+    """Reads the stacks out of the working tree, each compose file parsed once.
+
+    Once per *tree*, not once per call: a plan asks for the order and then for
+    what pulled each stack in, and `ci check-deps` asks three questions. Each is
+    a fresh read without this, which is 54 compose files parsed three times.
+    The tree is built per invocation, so it never outlives the working copy.
+    """
 
     def __init__(self, filesystem: FileSystem, repo_root: str | Path = ".") -> None:
         self._fs = filesystem
         self._root = Path(repo_root)
+        self._stacks: dict[str, Stack] | None = None
 
     def stacks(self) -> dict[str, Stack]:
+        if self._stacks is None:
+            self._stacks = self._read()
+        return self._stacks
+
+    def _read(self) -> dict[str, Stack]:
         stacks: dict[str, Stack] = {}
         for stack_root in STACK_ROOTS:
             for path in self._fs.glob(self._root / stack_root, "*/docker-compose.yml"):

--- a/tools/ci/ci/stackgraph.py
+++ b/tools/ci/ci/stackgraph.py
@@ -138,6 +138,38 @@ class DependencyGraph:
         """Deploy order: every stack after all of its dependencies."""
         return resolve(self.edges(), targets, sorted(self.disabled()))
 
+    def required_by(self, targets: list[str]) -> dict[str, list[str]]:
+        """For each stack a target pulls in, the targets that reach it."""
+        return required_by(self.edges(), targets, sorted(self.disabled()))
+
+
+def required_by(
+    graph: dict[str, list[str]],
+    targets: list[str],
+    disabled: list[str] | None = None,
+) -> dict[str, list[str]]:
+    """Stack -> the named targets that reach it, transitively, over the declarations.
+
+    A target never appears as its own dependency: `deploy paperless` reports
+    reverse-proxy as required by paperless even though authentik sits between
+    them, because paperless is the thing that was asked for.
+    """
+    off = set(disabled or ())
+    edges = {s: set(r) - off for s, r in graph.items() if s not in off}
+    reached: dict[str, set[str]] = {}
+    for target in targets:
+        if target in off:
+            continue
+        seen: set[str] = set()
+        frontier = list(edges.get(target, ()))
+        while frontier:
+            if (stack := frontier.pop()) not in seen:
+                seen.add(stack)
+                frontier.extend(edges.get(stack, ()))
+        for stack in seen:
+            reached.setdefault(stack, set()).add(target)
+    return {stack: sorted(ts) for stack, ts in reached.items()}
+
 
 def cycle_members(edges: dict[str, list[str]], stuck: list[str]) -> list[str]:
     """The stacks actually in a cycle, dropping those merely blocked behind one."""

--- a/tools/ci/ci/stackgraph.py
+++ b/tools/ci/ci/stackgraph.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -159,28 +160,56 @@ class DependencyGraph:
         return required_by(self.edges(), targets, sorted(self.disabled()))
 
 
-class DependencyCheck:
+def check_dependencies(graph: DependencyGraph) -> int:
     """The verdict `ci check-deps` prints: the declarations resolve, and are complete."""
+    try:
+        stacks = graph.stacks()
+        graph.resolve()
+    except UnresolvedGraph as exc:
+        log.error("✗ %s", exc)
+        return 1
+    if missing := graph.undeclared():
+        log.error(
+            "✗ dependencies visible in the compose file but not declared in x-homelab.requires:"
+        )
+        for stack, requires in sorted(missing.items()):
+            log.error("    %s: %s", stack, ", ".join(sorted(requires)))
+        return 1
+    log.info("✓ %d stacks resolve, with every dependency they reveal declared", len(stacks))
+    return 0
 
-    def __init__(self, graph: DependencyGraph) -> None:
-        self._graph = graph
 
-    def report(self) -> int:
-        try:
-            stacks = self._graph.stacks()
-            self._graph.resolve()
-        except UnresolvedGraph as exc:
-            log.error("✗ %s", exc)
-            return 1
-        if missing := self._graph.undeclared():
-            log.error(
-                "✗ dependencies visible in the compose file but not declared in x-homelab.requires:"
-            )
-            for stack, requires in sorted(missing.items()):
-                log.error("    %s: %s", stack, ", ".join(sorted(requires)))
-            return 1
-        log.info("✓ %d stacks resolve, with every dependency they reveal declared", len(stacks))
-        return 0
+def _declared_edges(
+    graph: dict[str, list[str]], disabled: list[str] | None = None
+) -> dict[str, set[str]]:
+    """The declarations with disabled providers, and the edges into them, dropped.
+
+    Raises rather than resolving a graph that names a stack which does not
+    exist. Every walk over the declarations starts here, so they all agree
+    about what counts as broken.
+    """
+    off = set(disabled or ())
+    edges = {s: set(requires) - off for s, requires in graph.items() if s not in off}
+    if unknown := {(s, d) for s, ds in edges.items() for d in ds if d not in edges}:
+        detail = ", ".join(f"{s} requires {d}" for s, d in sorted(unknown))
+        raise UnresolvedGraph(f"dependency on a stack that does not exist: {detail}")
+    return edges
+
+
+def _check_targets(graph: dict[str, list[str]], targets: list[str]) -> None:
+    if missing := sorted(set(targets) - set(graph)):
+        raise UnresolvedGraph(f"no such stack: {', '.join(missing)}")
+
+
+def _reachable(edges: dict[str, set[str]], start: str) -> set[str]:
+    """Everything `start` depends on, transitively. Never includes `start` itself."""
+    seen: set[str] = set()
+    frontier = list(edges.get(start, ()))
+    while frontier:
+        if (stack := frontier.pop()) not in seen:
+            seen.add(stack)
+            frontier.extend(edges.get(stack, ()))
+    return seen
 
 
 def required_by(
@@ -194,24 +223,18 @@ def required_by(
     reverse-proxy as required by paperless even though authentik sits between
     them, because paperless is the thing that was asked for.
     """
-    off = set(disabled or ())
-    edges = {s: set(r) - off for s, r in graph.items() if s not in off}
+    edges = _declared_edges(graph, disabled)
+    _check_targets(graph, targets)
     reached: dict[str, set[str]] = {}
     for target in targets:
-        if target in off:
+        if target not in edges:
             continue
-        seen: set[str] = set()
-        frontier = list(edges.get(target, ()))
-        while frontier:
-            if (stack := frontier.pop()) not in seen:
-                seen.add(stack)
-                frontier.extend(edges.get(stack, ()))
-        for stack in seen:
+        for stack in _reachable(edges, target):
             reached.setdefault(stack, set()).add(target)
     return {stack: sorted(ts) for stack, ts in reached.items()}
 
 
-def cycle_members(edges: dict[str, list[str]], stuck: list[str]) -> list[str]:
+def cycle_members(edges: Mapping[str, Collection[str]], stuck: list[str]) -> list[str]:
     """The stacks actually in a cycle, dropping those merely blocked behind one."""
     members = set(stuck)
     while shed := {s for s in members if not any(s in edges[o] for o in members)}:
@@ -230,35 +253,25 @@ def resolve(
     ``disabled`` names providers this environment does without — they are
     dropped, and so are the edges into them, rather than failing to resolve.
     """
-    off = set(disabled or ())
-    edges = {
-        stack: sorted(set(requires) - off)
-        for stack, requires in graph.items()
-        if stack not in off
-    }
+    edges = _declared_edges(graph, disabled)
 
-    if unknown := {(s, d) for s, ds in edges.items() for d in ds if d not in edges}:
-        detail = ", ".join(f"{s} requires {d}" for s, d in sorted(unknown))
-        raise UnresolvedGraph(f"dependency on a stack that does not exist: {detail}")
-
-    wanted = set(edges)
-    if targets is not None:
-        if missing := sorted(set(targets) - set(graph)):
-            raise UnresolvedGraph(f"no such stack: {', '.join(missing)}")
-        wanted, frontier = set(), [t for t in targets if t not in off]
-        while frontier:
-            if (stack := frontier.pop()) not in wanted:
-                wanted.add(stack)
-                frontier.extend(edges[stack])
+    if targets is None:
+        wanted = set(edges)
+    else:
+        _check_targets(graph, targets)
+        named = {t for t in targets if t in edges}
+        wanted = named.union(*(_reachable(edges, t) for t in named)) if named else set()
 
     order: list[str] = []
     placed: set[str] = set()
     # Alphabetical among stacks whose dependencies are all placed, so the same
     # graph always yields the same order.
     while remaining := sorted(wanted - placed):
-        ready = [s for s in remaining if not set(edges[s]) - placed]
+        ready = [s for s in remaining if not edges[s] - placed]
         if not ready:
-            raise UnresolvedGraph(f"dependency cycle among: {', '.join(cycle_members(edges, remaining))}")
+            raise UnresolvedGraph(
+                f"dependency cycle among: {', '.join(cycle_members(edges, remaining))}"
+            )
         order.extend(ready)
         placed.update(ready)
     return order

--- a/tools/ci/ci/stackgraph.py
+++ b/tools/ci/ci/stackgraph.py
@@ -10,6 +10,7 @@ Nothing here deploys — it only decides what order a deploy would use, and
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,7 +18,9 @@ from pathlib import Path
 import yaml
 
 from ci.config import disabled_providers
-from ci.ports import Console, FileSystem
+from ci.ports import FileSystem
+
+log = logging.getLogger(__name__)
 
 # Stacks live one directory deep in each of these, alongside a docker-compose.yml.
 STACK_ROOTS = ("stacks", "stacks/apps")
@@ -147,27 +150,24 @@ class DependencyGraph:
 class DependencyCheck:
     """The verdict `ci check-deps` prints: the declarations resolve, and are complete."""
 
-    def __init__(self, graph: DependencyGraph, console: Console) -> None:
+    def __init__(self, graph: DependencyGraph) -> None:
         self._graph = graph
-        self._console = console
 
     def report(self) -> int:
         try:
             stacks = self._graph.stacks()
             self._graph.resolve()
         except UnresolvedGraph as exc:
-            self._console.out(f"✗ {exc}")
+            log.error("✗ %s", exc)
             return 1
         if missing := self._graph.undeclared():
-            self._console.out(
+            log.error(
                 "✗ dependencies visible in the compose file but not declared in x-homelab.requires:"
             )
             for stack, requires in sorted(missing.items()):
-                self._console.out(f"    {stack}: {', '.join(sorted(requires))}")
+                log.error("    %s: %s", stack, ", ".join(sorted(requires)))
             return 1
-        self._console.out(
-            f"✓ {len(stacks)} stacks resolve, with every dependency they reveal declared"
-        )
+        log.info("✓ %d stacks resolve, with every dependency they reveal declared", len(stacks))
         return 0
 
 

--- a/tools/ci/pyproject.toml
+++ b/tools/ci/pyproject.toml
@@ -21,3 +21,7 @@ packages = ["ci"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# The e2e tier builds a throwaway swarm, so it is opt-in: `ci test --tier e2e`
+# clears addopts (a single tier is never coverage-gated), which re-selects it.
+addopts = "-m 'not e2e'"
+markers = ["e2e: needs a real docker swarm on the local daemon"]

--- a/tools/ci/tests/conftest.py
+++ b/tools/ci/tests/conftest.py
@@ -1,7 +1,8 @@
 """Fakes for the outer ring, and the container fixtures that inject them.
 
 These stand in for :mod:`ci.ports` — interfaces we own — so no test patches a
-stdlib or third-party name. The command boundary is a ``Mock(spec=CommandRunner)``
+stdlib or third-party name. Diagnostics are not among them: services log those
+through :mod:`logging`, and tests read them with ``caplog``. The command boundary is a ``Mock(spec=CommandRunner)``
 so ``assert_called_with`` validates it; the filesystem is a hand fake because it
 is stateful and a Mock would say nothing useful about a tree.
 
@@ -10,6 +11,7 @@ is stateful and a Mock would say nothing useful about a tree.
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from unittest.mock import Mock
@@ -73,24 +75,26 @@ class FixedClock:
         return self.timestamp
 
 
-class RecordingConsole:
+class RecordingOutput:
+    """Stands in for the payload stream — what a caller pipes or parses."""
+
     def __init__(self) -> None:
-        self.stdout: list[str] = []
-        self.stderr: list[str] = []
-        self.written: list[str] = []
+        self.lines: list[str] = []
+        self.raw_stdout: list[str] = []
+        self.raw_stderr: list[str] = []
 
-    def out(self, message: str = "") -> None:
-        self.stdout.append(message)
+    def line(self, text: str = "") -> None:
+        self.lines.append(text)
 
-    def err(self, message: str = "") -> None:
-        self.stderr.append(message)
+    def raw(self, text: str) -> None:
+        self.raw_stdout.append(text)
 
-    def write(self, text: str) -> None:
-        self.written.append(text)
+    def raw_err(self, text: str) -> None:
+        self.raw_stderr.append(text)
 
     @property
     def text(self) -> str:
-        return "\n".join(self.stdout)
+        return "\n".join(self.lines)
 
 
 def responds(commands: Mock, *results: CommandResult) -> None:
@@ -128,8 +132,14 @@ def clock() -> FixedClock:
 
 
 @pytest.fixture
-def console() -> RecordingConsole:
-    return RecordingConsole()
+def output() -> RecordingOutput:
+    return RecordingOutput()
+
+
+@pytest.fixture(autouse=True)
+def _diagnostics(caplog):
+    """Diagnostics are logged, so every test captures them at INFO by default."""
+    caplog.set_level(logging.INFO)
 
 
 @pytest.fixture
@@ -139,7 +149,7 @@ def env() -> dict[str, str]:
 
 
 @pytest.fixture
-def container(filesystem, commands, clock, console, env) -> Container:
+def container(filesystem, commands, clock, output, env) -> Container:
     """A container with every outer-ring provider overridden by a fake."""
     c = Container()
     c.repo_root.override(providers.Object(str(ROOT)))
@@ -147,7 +157,7 @@ def container(filesystem, commands, clock, console, env) -> Container:
     c.filesystem.override(providers.Object(filesystem))
     c.commands.override(providers.Object(commands))
     c.clock.override(providers.Object(clock))
-    c.console.override(providers.Object(console))
+    c.output.override(providers.Object(output))
     return c
 
 

--- a/tools/ci/tests/conftest.py
+++ b/tools/ci/tests/conftest.py
@@ -1,8 +1,9 @@
 """Fakes for the outer ring, and the container fixtures that inject them.
 
 These stand in for :mod:`ci.ports` — interfaces we own — so no test patches a
-stdlib or third-party name. Diagnostics are not among them: services log those
-through :mod:`logging`, and tests read them with ``caplog``. The command boundary is a ``Mock(spec=CommandRunner)``
+stdlib or third-party name. Process output is not among them: diagnostics go
+through :mod:`logging` (read with ``caplog``) and payload goes to stdout (read
+with ``capsys``) — both already have a seam, so owning one would add nothing. The command boundary is a ``Mock(spec=CommandRunner)``
 so ``assert_called_with`` validates it; the filesystem is a hand fake because it
 is stateful and a Mock would say nothing useful about a tree.
 
@@ -75,28 +76,6 @@ class FixedClock:
         return self.timestamp
 
 
-class RecordingOutput:
-    """Stands in for the payload stream — what a caller pipes or parses."""
-
-    def __init__(self) -> None:
-        self.lines: list[str] = []
-        self.raw_stdout: list[str] = []
-        self.raw_stderr: list[str] = []
-
-    def line(self, text: str = "") -> None:
-        self.lines.append(text)
-
-    def raw(self, text: str) -> None:
-        self.raw_stdout.append(text)
-
-    def raw_err(self, text: str) -> None:
-        self.raw_stderr.append(text)
-
-    @property
-    def text(self) -> str:
-        return "\n".join(self.lines)
-
-
 def responds(commands: Mock, *results: CommandResult) -> None:
     """Queue results for the next calls; anything after them succeeds silently."""
     queued = list(results)
@@ -131,10 +110,6 @@ def clock() -> FixedClock:
     return FixedClock()
 
 
-@pytest.fixture
-def output() -> RecordingOutput:
-    return RecordingOutput()
-
 
 @pytest.fixture(autouse=True)
 def _diagnostics(caplog):
@@ -149,7 +124,7 @@ def env() -> dict[str, str]:
 
 
 @pytest.fixture
-def container(filesystem, commands, clock, output, env) -> Container:
+def container(filesystem, commands, clock, env) -> Container:
     """A container with every outer-ring provider overridden by a fake."""
     c = Container()
     c.repo_root.override(providers.Object(str(ROOT)))
@@ -157,7 +132,6 @@ def container(filesystem, commands, clock, output, env) -> Container:
     c.filesystem.override(providers.Object(filesystem))
     c.commands.override(providers.Object(commands))
     c.clock.override(providers.Object(clock))
-    c.output.override(providers.Object(output))
     return c
 
 

--- a/tools/ci/tests/conftest.py
+++ b/tools/ci/tests/conftest.py
@@ -18,6 +18,7 @@ import pytest
 from dependency_injector import providers
 
 from ci.adapters import CommandResult
+from ci.config import load_env
 from ci.containers import Container
 from ci.ports import CommandRunner
 
@@ -99,7 +100,12 @@ def responds(commands: Mock, *results: CommandResult) -> None:
 
 
 def argvs(commands: Mock) -> list[list[str]]:
-    """The argv of every command the runner was asked to run, in order."""
+    """The argv of every command the runner was asked to run, in order.
+
+    Preferred over ``assert_called_with`` at this boundary: what matters is the
+    whole sequence a subcommand issues, and a list of argvs shows an unexpected
+    extra call — which a per-call assertion silently ignores.
+    """
     return [call.args[0] for call in commands.run.call_args_list]
 
 
@@ -136,8 +142,8 @@ def env() -> dict[str, str]:
 def container(filesystem, commands, clock, console, env) -> Container:
     """A container with every outer-ring provider overridden by a fake."""
     c = Container()
-    c.config.repo_root.from_value(str(ROOT))
-    c.config.env.from_value(env)
+    c.repo_root.override(providers.Object(str(ROOT)))
+    c.env.override(providers.Object(env))
     c.filesystem.override(providers.Object(filesystem))
     c.commands.override(providers.Object(commands))
     c.clock.override(providers.Object(clock))
@@ -148,9 +154,7 @@ def container(filesystem, commands, clock, console, env) -> Container:
 @pytest.fixture
 def repo_container() -> Container:
     """A real container pointed at this repository — the integration seam."""
-    from ci.config import load_env
-
     c = Container()
-    c.config.repo_root.from_value(str(REPO_ROOT))
-    c.config.env.from_value(load_env(c.filesystem(), REPO_ROOT, {}))
+    c.repo_root.override(providers.Object(str(REPO_ROOT)))
+    c.env.override(providers.Object(load_env(c.filesystem(), REPO_ROOT, {})))
     return c

--- a/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
+++ b/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
@@ -1,19 +1,12 @@
 """`SwarmCluster` against a real Swarm, on a throwaway single-node cluster.
 
-The unit suite feeds :class:`SwarmCluster` replica columns written by hand, so
-it proves the parsing but not that Docker still prints what we parse. It also
-never observes ``PRESENT``: every stack in the homelab is converged, so the one
-state that means "deployed but not there yet" has only ever existed in a fake.
+The unit suite feeds it replica columns written by hand, so it proves the
+parsing but not that Docker still prints what we parse — and it never observes
+``PRESENT``, because every stack in the homelab is converged.
 
-This deploys two probe stacks and reads them back:
-
-  ci-plan-probe   one service converges, one can never be scheduled  -> PRESENT
-  ci-plan-ok      one service, converged                             -> CONVERGED
-  ci-plan-absent  never deployed                                     -> ABSENT
-
-It runs against the **local** daemon only, never the operator's cluster: the
-context is pinned to ``default`` for the whole module and the suite skips if
-that daemon is missing. A swarm it initialised is a swarm it leaves.
+Runs against the local daemon only: the context is pinned to ``default`` and
+the suite skips if that daemon is missing. A swarm it starts is a swarm it
+leaves.
 """
 
 from __future__ import annotations
@@ -29,14 +22,11 @@ from ci.cluster import SERVICE_LS, StackState, SwarmCluster, parse_replicas
 PROBE = "ci-plan-probe"
 CONVERGED = "ci-plan-ok"
 NEVER_DEPLOYED = "ci-plan-absent"
-pytestmark = pytest.mark.e2e
-
 IMAGE = "alpine:3"
 TIMEOUT_SECONDS = 180
 
 # `stuck` carries a constraint no node satisfies, so its task never leaves
-# pending and the service sits at 0/1 — which is what makes the stack PRESENT
-# rather than CONVERGED. `ready` is what proves the difference is real.
+# pending and the service sits at 0/1 — which is what makes the stack PRESENT.
 PROBE_COMPOSE = f"""
 services:
     ready:
@@ -57,23 +47,32 @@ services:
         command: ["sleep", "600"]
 """
 
+SETTLED = {
+    f"{CONVERGED}_ready": "1/1",
+    f"{PROBE}_ready": "1/1",
+    f"{PROBE}_stuck": "0/1",
+}
+
 
 def docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["docker", *args], capture_output=True, text=True, check=check)
 
 
-def state_of(stack: str) -> StackState:
-    """A fresh cluster each call — `SwarmCluster` caches, so polling needs a new one."""
-    return SwarmCluster(Subprocess()).state(stack)
+def replicas() -> dict[str, str]:
+    """What `docker service ls` reports, read without the code under test."""
+    rows = (line.partition("\t") for line in docker(*SERVICE_LS[1:]).stdout.splitlines())
+    return {name: column for name, _, column in rows if name}
 
 
-def _await(stack: str, wanted: StackState) -> None:
+def _await_settled() -> None:
+    """Wait on Docker's own view, so the assertions are not just echoing setup."""
+    seen: dict[str, str] = {}
     deadline = time.monotonic() + TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        if (seen := state_of(stack)) is wanted:
+        if (seen := {k: v for k, v in replicas().items() if k in SETTLED}) == SETTLED:
             return
         time.sleep(2)
-    raise AssertionError(f"{stack} was {seen.value}, not {wanted.value}, after {TIMEOUT_SECONDS}s")
+    raise AssertionError(f"probe stacks settled at {seen}, wanted {SETTLED}")
 
 
 @pytest.fixture(scope="module")
@@ -83,11 +82,11 @@ def swarm(tmp_path_factory):
     patch.setenv("DOCKER_CONTEXT", "default")
     patch.delenv("DOCKER_HOST", raising=False)
     try:
-        probe = docker("info", "--format", "{{.Swarm.LocalNodeState}}", check=False)
-        if probe.returncode != 0:
-            pytest.skip(f"no local docker daemon: {probe.stderr.strip()}")
+        node = docker("info", "--format", "{{.Swarm.LocalNodeState}}", check=False)
+        if node.returncode != 0:
+            pytest.skip(f"no local docker daemon: {node.stderr.strip()}")
 
-        ours = probe.stdout.strip() == "inactive"
+        ours = node.stdout.strip() == "inactive"
         if ours and (init := docker(
             "swarm", "init", "--advertise-addr", "127.0.0.1", check=False
         )).returncode != 0:
@@ -96,11 +95,9 @@ def swarm(tmp_path_factory):
         try:
             tmp = tmp_path_factory.mktemp("probe")
             for stack, compose in ((PROBE, PROBE_COMPOSE), (CONVERGED, CONVERGED_COMPOSE)):
-                path = tmp / f"{stack}.yml"
-                path.write_text(compose)
+                (path := tmp / f"{stack}.yml").write_text(compose)
                 docker("stack", "deploy", "-c", str(path), stack)
-            _await(CONVERGED, StackState.CONVERGED)
-            _await(PROBE, StackState.PRESENT)
+            _await_settled()
             yield
         finally:
             for stack in (PROBE, CONVERGED):
@@ -111,26 +108,17 @@ def swarm(tmp_path_factory):
         patch.undo()
 
 
-def test_state_a_stack_short_of_its_replicas_is_present(swarm):
-    assert state_of(PROBE) is StackState.PRESENT
+@pytest.mark.e2e
+def test_state_reports_each_stack_as_the_cluster_actually_holds_it(swarm):
+    cluster = SwarmCluster(Subprocess())
+    assert {name: cluster.state(name) for name in (CONVERGED, PROBE, NEVER_DEPLOYED)} == {
+        CONVERGED: StackState.CONVERGED,
+        PROBE: StackState.PRESENT,
+        NEVER_DEPLOYED: StackState.ABSENT,
+    }
 
 
-def test_state_a_stack_at_its_desired_replicas_is_converged(swarm):
-    assert state_of(CONVERGED) is StackState.CONVERGED
-
-
-def test_state_a_stack_that_was_never_deployed_is_absent(swarm):
-    assert state_of(NEVER_DEPLOYED) is StackState.ABSENT
-
-
+@pytest.mark.e2e
 def test_parse_replicas_reads_every_column_a_real_swarm_prints(swarm):
-    """The guard against Docker changing the column out from under the parser."""
-    rows = [
-        line.partition("\t")
-        for line in docker(*SERVICE_LS[1:]).stdout.splitlines()
-        if line.strip()
-    ]
-    assert rows, "the probe stacks should have produced services to read"
-    for name, _, replicas in rows:
-        running, _ = parse_replicas(replicas)
-        assert running >= 0, f"{name}: unparsed replicas column {replicas!r}"
+    assert (columns := replicas()), "the probe stacks should have produced services"
+    assert all(parse_replicas(column)[0] >= 0 for column in columns.values()), columns

--- a/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
+++ b/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
@@ -1,8 +1,13 @@
-"""`SwarmCluster` against a real Swarm, on a throwaway single-node cluster.
+"""`ci deploy --plan` end to end: the real CLI against a real Swarm.
 
-The unit suite feeds it replica columns written by hand, so it proves the
-parsing but not that Docker still prints what we parse — and it never observes
-``PRESENT``, because every stack in the homelab is converged.
+Everything below the command line is exercised for real — argv parsing, the
+composition root, the stack tree, dependency resolution, the cluster read, and
+the rendered plan on stdout. The only fixture is the world: a throwaway
+single-node swarm carrying stacks whose compose files are also the repo the CLI
+is pointed at, so the manifest and the deployment cannot disagree.
+
+It is also the only place ``PRESENT`` is observed, since every stack in the
+homelab is converged.
 
 Runs against the local daemon only: the context is pinned to ``default`` and
 the suite skips if that daemon is missing. A swarm it starts is a swarm it
@@ -12,27 +17,30 @@ leaves.
 from __future__ import annotations
 
 import subprocess
+import sys
 import time
+from pathlib import Path
 
 import pytest
 
-from ci.adapters import Subprocess
-from ci.cluster import SERVICE_LS, StackState, SwarmCluster, parse_replicas
+from ci.cluster import SERVICE_LS
 
-PROBE = "ci-plan-probe"
-CONVERGED = "ci-plan-ok"
-NEVER_DEPLOYED = "ci-plan-absent"
+OK = "ci-plan-ok"  # deployed, converges
+PROBE = "ci-plan-probe"  # deployed, one service can never schedule
+ABSENT = "ci-plan-absent"  # declared in the repo, never deployed
 IMAGE = "alpine:3"
 TIMEOUT_SECONDS = 180
 
-# `stuck` carries a constraint no node satisfies, so its task never leaves
-# pending and the service sits at 0/1 — which is what makes the stack PRESENT.
-PROBE_COMPOSE = f"""
+SERVICE = f"""
 services:
     ready:
         image: {IMAGE}
         command: ["sleep", "600"]
-    stuck:
+"""
+
+# `stuck` carries a constraint no node satisfies, so its task never leaves
+# pending and the service sits at 0/1 — which is what makes the stack PRESENT.
+PROBE_SERVICE = SERVICE + f"""    stuck:
         image: {IMAGE}
         command: ["sleep", "600"]
         deploy:
@@ -40,18 +48,13 @@ services:
                 constraints: ["node.labels.{PROBE} == yes"]
 """
 
-CONVERGED_COMPOSE = f"""
-services:
-    ready:
-        image: {IMAGE}
-        command: ["sleep", "600"]
-"""
-
-SETTLED = {
-    f"{CONVERGED}_ready": "1/1",
-    f"{PROBE}_ready": "1/1",
-    f"{PROBE}_stuck": "0/1",
+REPO = {
+    OK: SERVICE,
+    ABSENT: SERVICE,
+    PROBE: f"x-homelab:\n    requires: [{OK}]\n" + PROBE_SERVICE,
 }
+DEPLOYED = (OK, PROBE)
+SETTLED = {f"{OK}_ready": "1/1", f"{PROBE}_ready": "1/1", f"{PROBE}_stuck": "0/1"}
 
 
 def docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -76,8 +79,8 @@ def _await_settled() -> None:
 
 
 @pytest.fixture(scope="module")
-def swarm(tmp_path_factory):
-    """A single-node swarm on the local daemon, carrying the two probe stacks."""
+def repo(tmp_path_factory):
+    """A repo of probe stacks, deployed to a throwaway swarm on the local daemon."""
     patch = pytest.MonkeyPatch()
     patch.setenv("DOCKER_CONTEXT", "default")
     patch.delenv("DOCKER_HOST", raising=False)
@@ -92,15 +95,18 @@ def swarm(tmp_path_factory):
         )).returncode != 0:
             pytest.skip(f"cannot init a local swarm: {init.stderr.strip()}")
 
+        root = tmp_path_factory.mktemp("repo")
+        for stack, compose in REPO.items():
+            path = root / "stacks" / "apps" / stack / "docker-compose.yml"
+            path.parent.mkdir(parents=True)
+            path.write_text(compose)
         try:
-            tmp = tmp_path_factory.mktemp("probe")
-            for stack, compose in ((PROBE, PROBE_COMPOSE), (CONVERGED, CONVERGED_COMPOSE)):
-                (path := tmp / f"{stack}.yml").write_text(compose)
-                docker("stack", "deploy", "-c", str(path), stack)
+            for stack in DEPLOYED:
+                docker("stack", "deploy", "-c", str(compose_of(root, stack)), stack)
             _await_settled()
-            yield
+            yield root
         finally:
-            for stack in (PROBE, CONVERGED):
+            for stack in DEPLOYED:
                 docker("stack", "rm", stack, check=False)
             if ours:
                 docker("swarm", "leave", "--force", check=False)
@@ -108,17 +114,47 @@ def swarm(tmp_path_factory):
         patch.undo()
 
 
-@pytest.mark.e2e
-def test_state_reports_each_stack_as_the_cluster_actually_holds_it(swarm):
-    cluster = SwarmCluster(Subprocess())
-    assert {name: cluster.state(name) for name in (CONVERGED, PROBE, NEVER_DEPLOYED)} == {
-        CONVERGED: StackState.CONVERGED,
-        PROBE: StackState.PRESENT,
-        NEVER_DEPLOYED: StackState.ABSENT,
-    }
+def compose_of(root: Path, stack: str) -> Path:
+    return root / "stacks" / "apps" / stack / "docker-compose.yml"
+
+
+def ci(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the real CLI as its own process, against the probe repo."""
+    return subprocess.run(
+        [sys.executable, "-m", "ci.cli", *args, "--repo-root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def plan_of(result: subprocess.CompletedProcess[str]) -> list[str]:
+    return [" ".join(line.split()) for line in result.stdout.splitlines()]
 
 
 @pytest.mark.e2e
-def test_parse_replicas_reads_every_column_a_real_swarm_prints(swarm):
-    assert (columns := replicas()), "the probe stacks should have produced services"
-    assert all(parse_replicas(column)[0] >= 0 for column in columns.values()), columns
+def test_deploy_plans_every_stack_with_the_state_the_cluster_actually_holds(repo):
+    result = ci(repo, "deploy", "--plan")
+    assert result.returncode == 0, result.stderr
+    assert plan_of(result) == [
+        f"deploy {ABSENT} absent",
+        f"deploy {OK} converged",
+        f"deploy {PROBE} present",
+    ]
+    assert "3 stack(s) — plan only, nothing deployed." in result.stderr
+
+
+@pytest.mark.e2e
+def test_deploy_names_the_target_that_pulled_in_each_dependency(repo):
+    result = ci(repo, "deploy", PROBE, "--plan")
+    assert result.returncode == 0, result.stderr
+    assert plan_of(result) == [
+        f"ensure {OK} converged → required by {PROBE}",
+        f"deploy {PROBE} present → explicit target",
+    ]
+
+
+@pytest.mark.e2e
+def test_deploy_leaves_the_cluster_exactly_as_it_found_it(repo):
+    before = replicas()
+    ci(repo, "deploy", "--plan")
+    assert replicas() == before

--- a/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
+++ b/tools/ci/tests/e2e/test_cluster_state_against_a_real_swarm.py
@@ -1,0 +1,136 @@
+"""`SwarmCluster` against a real Swarm, on a throwaway single-node cluster.
+
+The unit suite feeds :class:`SwarmCluster` replica columns written by hand, so
+it proves the parsing but not that Docker still prints what we parse. It also
+never observes ``PRESENT``: every stack in the homelab is converged, so the one
+state that means "deployed but not there yet" has only ever existed in a fake.
+
+This deploys two probe stacks and reads them back:
+
+  ci-plan-probe   one service converges, one can never be scheduled  -> PRESENT
+  ci-plan-ok      one service, converged                             -> CONVERGED
+  ci-plan-absent  never deployed                                     -> ABSENT
+
+It runs against the **local** daemon only, never the operator's cluster: the
+context is pinned to ``default`` for the whole module and the suite skips if
+that daemon is missing. A swarm it initialised is a swarm it leaves.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+from ci.adapters import Subprocess
+from ci.cluster import SERVICE_LS, StackState, SwarmCluster, parse_replicas
+
+PROBE = "ci-plan-probe"
+CONVERGED = "ci-plan-ok"
+NEVER_DEPLOYED = "ci-plan-absent"
+pytestmark = pytest.mark.e2e
+
+IMAGE = "alpine:3"
+TIMEOUT_SECONDS = 180
+
+# `stuck` carries a constraint no node satisfies, so its task never leaves
+# pending and the service sits at 0/1 — which is what makes the stack PRESENT
+# rather than CONVERGED. `ready` is what proves the difference is real.
+PROBE_COMPOSE = f"""
+services:
+    ready:
+        image: {IMAGE}
+        command: ["sleep", "600"]
+    stuck:
+        image: {IMAGE}
+        command: ["sleep", "600"]
+        deploy:
+            placement:
+                constraints: ["node.labels.{PROBE} == yes"]
+"""
+
+CONVERGED_COMPOSE = f"""
+services:
+    ready:
+        image: {IMAGE}
+        command: ["sleep", "600"]
+"""
+
+
+def docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["docker", *args], capture_output=True, text=True, check=check)
+
+
+def state_of(stack: str) -> StackState:
+    """A fresh cluster each call — `SwarmCluster` caches, so polling needs a new one."""
+    return SwarmCluster(Subprocess()).state(stack)
+
+
+def _await(stack: str, wanted: StackState) -> None:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if (seen := state_of(stack)) is wanted:
+            return
+        time.sleep(2)
+    raise AssertionError(f"{stack} was {seen.value}, not {wanted.value}, after {TIMEOUT_SECONDS}s")
+
+
+@pytest.fixture(scope="module")
+def swarm(tmp_path_factory):
+    """A single-node swarm on the local daemon, carrying the two probe stacks."""
+    patch = pytest.MonkeyPatch()
+    patch.setenv("DOCKER_CONTEXT", "default")
+    patch.delenv("DOCKER_HOST", raising=False)
+    try:
+        probe = docker("info", "--format", "{{.Swarm.LocalNodeState}}", check=False)
+        if probe.returncode != 0:
+            pytest.skip(f"no local docker daemon: {probe.stderr.strip()}")
+
+        ours = probe.stdout.strip() == "inactive"
+        if ours and (init := docker(
+            "swarm", "init", "--advertise-addr", "127.0.0.1", check=False
+        )).returncode != 0:
+            pytest.skip(f"cannot init a local swarm: {init.stderr.strip()}")
+
+        try:
+            tmp = tmp_path_factory.mktemp("probe")
+            for stack, compose in ((PROBE, PROBE_COMPOSE), (CONVERGED, CONVERGED_COMPOSE)):
+                path = tmp / f"{stack}.yml"
+                path.write_text(compose)
+                docker("stack", "deploy", "-c", str(path), stack)
+            _await(CONVERGED, StackState.CONVERGED)
+            _await(PROBE, StackState.PRESENT)
+            yield
+        finally:
+            for stack in (PROBE, CONVERGED):
+                docker("stack", "rm", stack, check=False)
+            if ours:
+                docker("swarm", "leave", "--force", check=False)
+    finally:
+        patch.undo()
+
+
+def test_state_a_stack_short_of_its_replicas_is_present(swarm):
+    assert state_of(PROBE) is StackState.PRESENT
+
+
+def test_state_a_stack_at_its_desired_replicas_is_converged(swarm):
+    assert state_of(CONVERGED) is StackState.CONVERGED
+
+
+def test_state_a_stack_that_was_never_deployed_is_absent(swarm):
+    assert state_of(NEVER_DEPLOYED) is StackState.ABSENT
+
+
+def test_parse_replicas_reads_every_column_a_real_swarm_prints(swarm):
+    """The guard against Docker changing the column out from under the parser."""
+    rows = [
+        line.partition("\t")
+        for line in docker(*SERVICE_LS[1:]).stdout.splitlines()
+        if line.strip()
+    ]
+    assert rows, "the probe stacks should have produced services to read"
+    for name, _, replicas in rows:
+        running, _ = parse_replicas(replicas)
+        assert running >= 0, f"{name}: unparsed replicas column {replicas!r}"

--- a/tools/ci/tests/unit/test_apptests.py
+++ b/tools/ci/tests/unit/test_apptests.py
@@ -124,9 +124,9 @@ class TestAppSuitesPythonRuns:
         rc, ran = container.suites().run_python([self.PROJECT], ["unit"])
         assert (rc, ran) == (1, True)
 
-    def test_the_project_is_announced_before_it_runs(self, subject, console):
+    def test_the_project_is_announced_before_it_runs(self, subject, caplog):
         subject.run_python([self.PROJECT], ["unit"])
-        assert console.stdout == [f"==> {self.PROJECT} : unit"]
+        assert caplog.messages == [f"==> {self.PROJECT} : unit"]
 
 
 class TestAppSuitesJsRuns:
@@ -182,11 +182,11 @@ class TestSuiteRunner:
         assert argvs(commands) == [["uv", "run", "pytest", "tests/unit"]]
 
     def test_a_selector_matching_nothing_runs_nothing_and_says_so(
-        self, subject, commands, console
+        self, subject, commands, caplog
     ):
         assert subject.run(selector="nope") == 0
         assert argvs(commands) == []
-        assert "No matching test suites." in console.text
+        assert "No matching test suites." in caplog.text
 
     def test_an_explicit_tier_clears_the_coverage_gate(self, subject, commands):
         subject.run(selector="warden", tier="unit")

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -66,24 +66,24 @@ class TestParser:
 class TestDeployCommand:
     """`ci deploy --plan` — prints a plan against live state, deploys nothing."""
 
-    def _fields(self, output) -> list[list[str]]:
-        return [line.split() for line in output.lines]
+    def _fields(self, capsys) -> list[list[str]]:
+        return [line.split() for line in capsys.readouterr().out.splitlines()]
 
-    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, output):
+    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, capsys):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "--plan") == 0
-        assert [row[1] for row in self._fields(output)] == ["reverse-proxy", "paperless"]
+        assert [row[1] for row in self._fields(capsys)] == ["reverse-proxy", "paperless"]
 
-    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, output):
+    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, capsys):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert self._fields(output) == [["deploy", "reverse-proxy", "absent"]]
+        assert self._fields(capsys) == [["deploy", "reverse-proxy", "absent"]]
 
     def test_a_stack_at_its_desired_replicas_reports_converged(
-        self, run, filesystem, output, commands
+        self, run, filesystem, capsys, commands
     ):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         responds(
@@ -92,18 +92,18 @@ class TestDeployCommand:
             CommandResult(0, "reverse-proxy_traefik\t1/1\n"),
         )
         run("deploy", "--plan")
-        assert self._fields(output) == [["deploy", "reverse-proxy", "converged"]]
+        assert self._fields(capsys) == [["deploy", "reverse-proxy", "converged"]]
 
     def test_reports_the_count_on_stderr_so_stdout_stays_pipeable(
-        self, run, filesystem, output, caplog
+        self, run, filesystem, capsys, caplog
     ):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert len(output.lines) == 1
+        assert len(capsys.readouterr().out.splitlines()) == 1
         assert "1 stack(s) — plan only, nothing deployed." in caplog.text
 
     def test_a_target_narrows_the_plan_to_its_closure_and_says_what_pulled_each_in(
-        self, run, filesystem, output
+        self, run, filesystem, capsys
     ):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
@@ -111,19 +111,19 @@ class TestDeployCommand:
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "paperless", "--plan") == 0
-        assert [" ".join(line.split()) for line in output.lines] == [
+        assert [" ".join(line.split()) for line in capsys.readouterr().out.splitlines()] == [
             "ensure reverse-proxy absent → required by paperless",
             "deploy paperless absent → explicit target",
         ]
 
     def test_an_unresolvable_graph_exits_one_and_explains_on_stderr(
-        self, run, filesystem, output, caplog
+        self, run, filesystem, capsys, caplog
     ):
         filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
             "x-homelab:\n    requires: [ghost-stack]\nservices: {}\n"
         )
         assert run("deploy", "--plan") == 1
-        assert output.lines == []
+        assert capsys.readouterr().out == ""
         assert "paperless requires ghost-stack" in caplog.text
 
     def test_it_only_ever_lists_the_cluster_never_changes_it(self, run, filesystem, commands):
@@ -176,24 +176,24 @@ class TestCheckDepsCommand:
 class TestAffectedCommand:
     """`ci affected` — the build matrix, as JSON on stdout."""
 
-    def test_emits_json_for_the_affected_units(self, run, filesystem, output):
+    def test_emits_json_for_the_affected_units(self, run, filesystem, capsys):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("affected", ".", "stacks/apps/warden/app/main.py") == 0
-        assert [e["image_name"] for e in json.loads(output.text)] == ["warden"]
+        assert [e["image_name"] for e in json.loads(capsys.readouterr().out)] == ["warden"]
 
-    def test_an_unrelated_change_emits_an_empty_matrix(self, run, filesystem, output):
+    def test_an_unrelated_change_emits_an_empty_matrix(self, run, filesystem, capsys):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("affected", ".", "docs/readme.md") == 0
-        assert json.loads(output.text) == []
+        assert json.loads(capsys.readouterr().out) == []
 
 
 class TestImagesCommand:
     """`ci images` — one buildable image name per line."""
 
-    def test_lists_every_image_once(self, run, filesystem, output, caplog):
+    def test_lists_every_image_once(self, run, filesystem, capsys, caplog):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("images") == 0
-        assert output.lines == ["warden"]
+        assert capsys.readouterr().out.splitlines() == ["warden"]
 
 
 class TestGcCommand:
@@ -270,27 +270,27 @@ class TestProjectsCommand:
             "tools/ci/tests/unit/test_y.py": "",
         })
 
-    def _projects(self, output) -> list[str]:
-        return [e["project"] for e in json.loads(output.text)]
+    def _projects(self, capsys) -> list[str]:
+        return [e["project"] for e in json.loads(capsys.readouterr().out)]
 
-    def test_a_change_inside_a_project_selects_that_project(self, run, output):
+    def test_a_change_inside_a_project_selects_that_project(self, run, capsys):
         assert run("projects", ".", f"{self.PY}/main.py") == 0
-        assert self._projects(output) == [self.PY]
+        assert self._projects(capsys) == [self.PY]
 
-    def test_a_change_to_the_ci_tooling_selects_the_ci_tooling(self, run, output):
+    def test_a_change_to_the_ci_tooling_selects_the_ci_tooling(self, run, capsys):
         assert run("projects", ".", "tools/ci/ci/stackgraph.py") == 0
-        assert "tools/ci" in self._projects(output)
+        assert "tools/ci" in self._projects(capsys)
 
-    def test_an_unrelated_change_selects_nothing(self, run, output):
+    def test_an_unrelated_change_selects_nothing(self, run, capsys):
         assert run("projects", ".", "docs/index.md") == 0
-        assert self._projects(output) == []
+        assert self._projects(capsys) == []
 
-    def test_the_output_is_a_github_matrix_include_list(self, run, output):
+    def test_the_output_is_a_github_matrix_include_list(self, run, capsys):
         run("projects", ".", f"{self.PY}/main.py")
-        entries = json.loads(output.text)
+        entries = json.loads(capsys.readouterr().out)
         assert entries == [{"project": self.PY}]
 
-    def test_a_project_that_builds_no_image_is_reachable_only_by_path(self, run, output):
+    def test_a_project_that_builds_no_image_is_reachable_only_by_path(self, run, capsys):
         # tools/ci has no compose unit, so nothing but a path edit can select it.
         run("projects", ".", f"{self.PY}/main.py")
-        assert "tools/ci" not in self._projects(output)
+        assert "tools/ci" not in self._projects(capsys)

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -64,108 +64,46 @@ class TestParser:
 
 
 class TestDeployCommand:
-    """`ci deploy --plan` — prints a plan against live state, deploys nothing."""
+    """`ci deploy --plan` — that argv reaches the plan and its verdict comes back.
 
-    def _fields(self, capsys) -> list[list[str]]:
-        return [line.split() for line in capsys.readouterr().out.splitlines()]
+    What the plan *says* is `test_deploy.py`'s job. These two assert only the
+    wiring: the payload reaches stdout, and a failure's exit code propagates.
+    """
 
-    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, capsys):
+    def test_the_plan_reaches_stdout_and_succeeds(self, run, filesystem, capsys):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "--plan") == 0
-        assert [row[1] for row in self._fields(capsys)] == ["reverse-proxy", "paperless"]
+        printed = capsys.readouterr().out
+        assert [line.split()[1] for line in printed.splitlines()] == ["reverse-proxy", "paperless"]
 
-    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, capsys):
-        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
-        run("deploy", "--plan")
-        assert self._fields(capsys) == [["deploy", "reverse-proxy", "absent"]]
-
-    def test_a_stack_at_its_desired_replicas_reports_converged(
-        self, run, filesystem, capsys, commands
-    ):
-        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
-        responds(
-            commands,
-            CommandResult(0, "reverse-proxy\n"),
-            CommandResult(0, "reverse-proxy_traefik\t1/1\n"),
-        )
-        run("deploy", "--plan")
-        assert self._fields(capsys) == [["deploy", "reverse-proxy", "converged"]]
-
-    def test_reports_the_count_on_stderr_so_stdout_stays_pipeable(
-        self, run, filesystem, capsys, caplog
-    ):
-        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
-        run("deploy", "--plan")
-        assert len(capsys.readouterr().out.splitlines()) == 1
-        assert "1 stack(s) — plan only, nothing deployed." in caplog.text
-
-    def test_a_target_narrows_the_plan_to_its_closure_and_says_what_pulled_each_in(
+    def test_a_plan_that_cannot_be_built_propagates_its_exit_code(
         self, run, filesystem, capsys
-    ):
-        filesystem.files.update({
-            "stacks/apps/paperless/docker-compose.yml": DECLARED,
-            "stacks/apps/komga/docker-compose.yml": DECLARED,
-            "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
-        })
-        assert run("deploy", "paperless", "--plan") == 0
-        assert [" ".join(line.split()) for line in capsys.readouterr().out.splitlines()] == [
-            "ensure reverse-proxy absent → required by paperless",
-            "deploy paperless absent → explicit target",
-        ]
-
-    def test_an_unresolvable_graph_exits_one_and_explains_on_stderr(
-        self, run, filesystem, capsys, caplog
     ):
         filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
             "x-homelab:\n    requires: [ghost-stack]\nservices: {}\n"
         )
         assert run("deploy", "--plan") == 1
         assert capsys.readouterr().out == ""
-        assert "paperless requires ghost-stack" in caplog.text
-
-    def test_it_only_ever_lists_the_cluster_never_changes_it(self, run, filesystem, commands):
-        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
-        run("deploy", "--plan")
-        assert [argv[:3] for argv in argvs(commands)] == [
-            ["docker", "stack", "ls"],
-            ["docker", "service", "ls"],
-        ]
 
 
 class TestCheckDepsCommand:
-    """`ci check-deps` — the pre-commit hook's entry point."""
+    """`ci check-deps` — the pre-commit hook's entry point.
 
-    def test_a_clean_tree_passes_and_reports_the_count(self, run, filesystem, caplog):
+    The verdicts themselves are `test_stackgraph.py::TestDependencyCheck`; these
+    assert that argv reaches it and both exit codes come back.
+    """
+
+    def test_a_clean_tree_exits_zero(self, run, filesystem):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("check-deps") == 0
-        assert "✓ 2 stacks resolve" in caplog.text
 
-    def test_an_undeclared_dependency_exits_one_naming_the_stack(
-        self, run, filesystem, caplog
-    ):
-        filesystem.files.update({
-            "stacks/apps/komga/docker-compose.yml": TRAEFIK,
-            "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
-        })
-        assert run("check-deps") == 1
-        assert "    komga: reverse-proxy" in caplog.text
-
-    def test_a_malformed_declaration_exits_one_explaining_the_shape(
-        self, run, filesystem, caplog
-    ):
-        filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
-            "x-homelab:\n    requires: reverse-proxy\nservices: {}\n"
-        )
-        assert run("check-deps") == 1
-        assert "x-homelab.requires must be a list" in caplog.text
-
-    def test_a_dangling_edge_from_a_deleted_stack_exits_one(self, run, filesystem, caplog):
+    def test_a_tree_that_does_not_check_out_exits_one(self, run, filesystem, caplog):
         filesystem.files["stacks/apps/gamarr/docker-compose.yml"] = (
             "x-homelab:\n    requires: [romm]\nservices: {}\n"
         )

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -64,32 +64,57 @@ class TestParser:
 
 
 class TestDeployCommand:
-    """`ci deploy --plan` — prints an order, deploys nothing."""
+    """`ci deploy --plan` — prints a plan against live state, deploys nothing."""
 
-    def test_prints_the_resolved_order_one_stack_per_line(self, run, filesystem, console):
+    def _fields(self, console) -> list[list[str]]:
+        return [line.split() for line in console.stdout]
+
+    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, console):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "--plan") == 0
-        assert console.stdout == ["reverse-proxy", "paperless"]
+        assert [row[1] for row in self._fields(console)] == ["reverse-proxy", "paperless"]
+
+    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, console):
+        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
+        run("deploy", "--plan")
+        assert self._fields(console) == [["deploy", "reverse-proxy", "absent"]]
+
+    def test_a_stack_at_its_desired_replicas_reports_converged(
+        self, run, filesystem, console, commands
+    ):
+        filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
+        responds(
+            commands,
+            CommandResult(0, "reverse-proxy\n"),
+            CommandResult(0, "reverse-proxy_traefik\t1/1\n"),
+        )
+        run("deploy", "--plan")
+        assert self._fields(console) == [["deploy", "reverse-proxy", "converged"]]
 
     def test_reports_the_count_on_stderr_so_stdout_stays_pipeable(
         self, run, filesystem, console
     ):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert console.stdout == ["reverse-proxy"]
+        assert len(console.stdout) == 1
         assert "1 stack(s) — plan only, nothing deployed." in "\n".join(console.stderr)
 
-    def test_a_target_narrows_the_plan_to_its_closure(self, run, filesystem, console):
+    def test_a_target_narrows_the_plan_to_its_closure_and_says_what_pulled_each_in(
+        self, run, filesystem, console
+    ):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/apps/komga/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "paperless", "--plan") == 0
-        assert console.stdout == ["reverse-proxy", "paperless"]
+        assert [" ".join(line.split()) for line in console.stdout] == [
+            "ensure reverse-proxy absent → required by paperless",
+            "deploy paperless absent → explicit target",
+        ]
 
     def test_an_unresolvable_graph_exits_one_and_explains_on_stderr(
         self, run, filesystem, console
@@ -101,10 +126,13 @@ class TestDeployCommand:
         assert console.stdout == []
         assert "paperless requires ghost-stack" in "\n".join(console.stderr)
 
-    def test_it_never_runs_a_command(self, run, filesystem, commands):
+    def test_it_only_ever_lists_the_cluster_never_changes_it(self, run, filesystem, commands):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert argvs(commands) == []
+        assert [argv[:3] for argv in argvs(commands)] == [
+            ["docker", "stack", "ls"],
+            ["docker", "service", "ls"],
+        ]
 
 
 class TestCheckDepsCommand:

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -66,24 +66,24 @@ class TestParser:
 class TestDeployCommand:
     """`ci deploy --plan` — prints a plan against live state, deploys nothing."""
 
-    def _fields(self, console) -> list[list[str]]:
-        return [line.split() for line in console.stdout]
+    def _fields(self, output) -> list[list[str]]:
+        return [line.split() for line in output.lines]
 
-    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, console):
+    def test_prints_a_row_per_stack_in_deploy_order(self, run, filesystem, output):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "--plan") == 0
-        assert [row[1] for row in self._fields(console)] == ["reverse-proxy", "paperless"]
+        assert [row[1] for row in self._fields(output)] == ["reverse-proxy", "paperless"]
 
-    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, console):
+    def test_a_stack_the_cluster_does_not_have_reports_absent(self, run, filesystem, output):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert self._fields(console) == [["deploy", "reverse-proxy", "absent"]]
+        assert self._fields(output) == [["deploy", "reverse-proxy", "absent"]]
 
     def test_a_stack_at_its_desired_replicas_reports_converged(
-        self, run, filesystem, console, commands
+        self, run, filesystem, output, commands
     ):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         responds(
@@ -92,18 +92,18 @@ class TestDeployCommand:
             CommandResult(0, "reverse-proxy_traefik\t1/1\n"),
         )
         run("deploy", "--plan")
-        assert self._fields(console) == [["deploy", "reverse-proxy", "converged"]]
+        assert self._fields(output) == [["deploy", "reverse-proxy", "converged"]]
 
     def test_reports_the_count_on_stderr_so_stdout_stays_pipeable(
-        self, run, filesystem, console
+        self, run, filesystem, output, caplog
     ):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
         run("deploy", "--plan")
-        assert len(console.stdout) == 1
-        assert "1 stack(s) — plan only, nothing deployed." in "\n".join(console.stderr)
+        assert len(output.lines) == 1
+        assert "1 stack(s) — plan only, nothing deployed." in caplog.text
 
     def test_a_target_narrows_the_plan_to_its_closure_and_says_what_pulled_each_in(
-        self, run, filesystem, console
+        self, run, filesystem, output
     ):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
@@ -111,20 +111,20 @@ class TestDeployCommand:
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("deploy", "paperless", "--plan") == 0
-        assert [" ".join(line.split()) for line in console.stdout] == [
+        assert [" ".join(line.split()) for line in output.lines] == [
             "ensure reverse-proxy absent → required by paperless",
             "deploy paperless absent → explicit target",
         ]
 
     def test_an_unresolvable_graph_exits_one_and_explains_on_stderr(
-        self, run, filesystem, console
+        self, run, filesystem, output, caplog
     ):
         filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
             "x-homelab:\n    requires: [ghost-stack]\nservices: {}\n"
         )
         assert run("deploy", "--plan") == 1
-        assert console.stdout == []
-        assert "paperless requires ghost-stack" in "\n".join(console.stderr)
+        assert output.lines == []
+        assert "paperless requires ghost-stack" in caplog.text
 
     def test_it_only_ever_lists_the_cluster_never_changes_it(self, run, filesystem, commands):
         filesystem.files["stacks/reverse-proxy/docker-compose.yml"] = "services: {}\n"
@@ -138,81 +138,81 @@ class TestDeployCommand:
 class TestCheckDepsCommand:
     """`ci check-deps` — the pre-commit hook's entry point."""
 
-    def test_a_clean_tree_passes_and_reports_the_count(self, run, filesystem, console):
+    def test_a_clean_tree_passes_and_reports_the_count(self, run, filesystem, caplog):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("check-deps") == 0
-        assert console.text.startswith("✓ 2 stacks resolve")
+        assert "✓ 2 stacks resolve" in caplog.text
 
     def test_an_undeclared_dependency_exits_one_naming_the_stack(
-        self, run, filesystem, console
+        self, run, filesystem, caplog
     ):
         filesystem.files.update({
             "stacks/apps/komga/docker-compose.yml": TRAEFIK,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("check-deps") == 1
-        assert "    komga: reverse-proxy" in console.text
+        assert "    komga: reverse-proxy" in caplog.text
 
     def test_a_malformed_declaration_exits_one_explaining_the_shape(
-        self, run, filesystem, console
+        self, run, filesystem, caplog
     ):
         filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
             "x-homelab:\n    requires: reverse-proxy\nservices: {}\n"
         )
         assert run("check-deps") == 1
-        assert "x-homelab.requires must be a list" in console.text
+        assert "x-homelab.requires must be a list" in caplog.text
 
-    def test_a_dangling_edge_from_a_deleted_stack_exits_one(self, run, filesystem, console):
+    def test_a_dangling_edge_from_a_deleted_stack_exits_one(self, run, filesystem, caplog):
         filesystem.files["stacks/apps/gamarr/docker-compose.yml"] = (
             "x-homelab:\n    requires: [romm]\nservices: {}\n"
         )
         assert run("check-deps") == 1
-        assert "gamarr requires romm" in console.text
+        assert "gamarr requires romm" in caplog.text
 
 
 class TestAffectedCommand:
     """`ci affected` — the build matrix, as JSON on stdout."""
 
-    def test_emits_json_for_the_affected_units(self, run, filesystem, console):
+    def test_emits_json_for_the_affected_units(self, run, filesystem, output):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("affected", ".", "stacks/apps/warden/app/main.py") == 0
-        assert [e["image_name"] for e in json.loads(console.text)] == ["warden"]
+        assert [e["image_name"] for e in json.loads(output.text)] == ["warden"]
 
-    def test_an_unrelated_change_emits_an_empty_matrix(self, run, filesystem, console):
+    def test_an_unrelated_change_emits_an_empty_matrix(self, run, filesystem, output):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("affected", ".", "docs/readme.md") == 0
-        assert json.loads(console.text) == []
+        assert json.loads(output.text) == []
 
 
 class TestImagesCommand:
     """`ci images` — one buildable image name per line."""
 
-    def test_lists_every_image_once(self, run, filesystem, console):
+    def test_lists_every_image_once(self, run, filesystem, output, caplog):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         assert run("images") == 0
-        assert console.stdout == ["warden"]
+        assert output.lines == ["warden"]
 
 
 class TestGcCommand:
     """`ci gc` — dry-run unless told otherwise."""
 
-    def test_defaults_to_a_dry_run(self, run, filesystem, commands, console):
+    def test_defaults_to_a_dry_run(self, run, filesystem, commands, caplog):
         filesystem.files["stacks/apps/warden/docker-compose.yml"] = BUILDABLE
         responds(commands, *[CommandResult(0, "[]")])
         assert run("gc") == 0
-        assert console.stdout[-1] == "Would prune 0 version(s)."
+        assert caplog.messages[-1] == "Would prune 0 version(s)."
         assert all("DELETE" not in a for argv in argvs(commands) for a in argv)
 
 
 class TestTestCommand:
     """`ci test` — selection and the suites it invokes."""
 
-    def test_no_matching_suite_says_so_and_still_succeeds(self, run, console):
+    def test_no_matching_suite_says_so_and_still_succeeds(self, run, caplog):
         assert run("test") == 0
-        assert "No matching test suites." in console.text
+        assert "No matching test suites." in caplog.text
 
     def test_runs_the_gated_default_suite_for_a_selected_app(self, run, filesystem, commands):
         filesystem.files["stacks/apps/warden/app/pyproject.toml"] = "[project]\n"
@@ -270,27 +270,27 @@ class TestProjectsCommand:
             "tools/ci/tests/unit/test_y.py": "",
         })
 
-    def _projects(self, console) -> list[str]:
-        return [e["project"] for e in json.loads(console.text)]
+    def _projects(self, output) -> list[str]:
+        return [e["project"] for e in json.loads(output.text)]
 
-    def test_a_change_inside_a_project_selects_that_project(self, run, console):
+    def test_a_change_inside_a_project_selects_that_project(self, run, output):
         assert run("projects", ".", f"{self.PY}/main.py") == 0
-        assert self._projects(console) == [self.PY]
+        assert self._projects(output) == [self.PY]
 
-    def test_a_change_to_the_ci_tooling_selects_the_ci_tooling(self, run, console):
+    def test_a_change_to_the_ci_tooling_selects_the_ci_tooling(self, run, output):
         assert run("projects", ".", "tools/ci/ci/stackgraph.py") == 0
-        assert "tools/ci" in self._projects(console)
+        assert "tools/ci" in self._projects(output)
 
-    def test_an_unrelated_change_selects_nothing(self, run, console):
+    def test_an_unrelated_change_selects_nothing(self, run, output):
         assert run("projects", ".", "docs/index.md") == 0
-        assert self._projects(console) == []
+        assert self._projects(output) == []
 
-    def test_the_output_is_a_github_matrix_include_list(self, run, console):
+    def test_the_output_is_a_github_matrix_include_list(self, run, output):
         run("projects", ".", f"{self.PY}/main.py")
-        entries = json.loads(console.text)
+        entries = json.loads(output.text)
         assert entries == [{"project": self.PY}]
 
-    def test_a_project_that_builds_no_image_is_reachable_only_by_path(self, run, console):
+    def test_a_project_that_builds_no_image_is_reachable_only_by_path(self, run, output):
         # tools/ci has no compose unit, so nothing but a path edit can select it.
         run("projects", ".", f"{self.PY}/main.py")
-        assert "tools/ci" not in self._projects(console)
+        assert "tools/ci" not in self._projects(output)

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -14,7 +14,7 @@ import pytest
 from conftest import ROOT, argvs, responds
 
 from ci.adapters import CommandResult
-from ci.cli import build_parser
+from ci.cli import build_container, build_parser
 
 TRAEFIK = 'services:\n    a:\n        deploy:\n            labels: ["traefik.enable=true"]\n'
 DECLARED = "x-homelab:\n    requires: [reverse-proxy]\n" + TRAEFIK
@@ -37,6 +37,29 @@ def run(container):
     container.unwire()
 
 
+# Every subcommand's argv must be enough to wire the container — the composition
+# root reads `--repo-root` off it, and nothing else checks that it is there.
+SUBCOMMANDS = [
+    ["affected"],
+    ["projects"],
+    ["images"],
+    ["gc"],
+    ["test"],
+    ["idempotence", "play.yml"],
+    ["deploy", "--plan"],
+    ["check-deps"],
+]
+
+
+@pytest.mark.parametrize("argv", SUBCOMMANDS, ids=lambda argv: argv[0])
+def test_build_container_wires_every_subcommand(argv):
+    container = build_container(build_parser().parse_args(argv), process_env={})
+    try:
+        assert container.repo_root() == "."
+    finally:
+        container.unwire()
+
+
 class TestParser:
     """`build_parser` — the argv contract, before any handler runs."""
 
@@ -47,6 +70,14 @@ class TestParser:
     def test_deploy_accepts_targets_with_plan(self):
         args = build_parser().parse_args(["deploy", "paperless", "komga", "--plan"])
         assert args.stacks == ["paperless", "komga"]
+
+    def test_idempotence_takes_repo_root_only_before_the_playbook(self):
+        """REMAINDER swallows everything after it, the flag included."""
+        before = build_parser().parse_args(["idempotence", "--repo-root", "/tmp", "play.yml"])
+        assert (before.repo_root, before.ansible_args) == ("/tmp", [])
+
+        after = build_parser().parse_args(["idempotence", "play.yml", "--repo-root", "/tmp"])
+        assert (after.repo_root, after.ansible_args) == (".", ["--repo-root", "/tmp"])
 
     def test_an_unknown_subcommand_is_rejected(self):
         with pytest.raises(SystemExit):

--- a/tools/ci/tests/unit/test_cli.py
+++ b/tools/ci/tests/unit/test_cli.py
@@ -70,7 +70,7 @@ class TestDeployCommand:
     wiring: the payload reaches stdout, and a failure's exit code propagates.
     """
 
-    def test_the_plan_reaches_stdout_and_succeeds(self, run, filesystem, capsys):
+    def test_deploy_prints_the_plan_and_exits_zero(self, run, filesystem, capsys):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
@@ -79,7 +79,7 @@ class TestDeployCommand:
         printed = capsys.readouterr().out
         assert [line.split()[1] for line in printed.splitlines()] == ["reverse-proxy", "paperless"]
 
-    def test_a_plan_that_cannot_be_built_propagates_its_exit_code(
+    def test_deploy_propagates_a_failed_plans_exit_code(
         self, run, filesystem, capsys
     ):
         filesystem.files["stacks/apps/paperless/docker-compose.yml"] = (
@@ -96,14 +96,14 @@ class TestCheckDepsCommand:
     assert that argv reaches it and both exit codes come back.
     """
 
-    def test_a_clean_tree_exits_zero(self, run, filesystem):
+    def test_check_deps_exits_zero_for_a_clean_tree(self, run, filesystem):
         filesystem.files.update({
             "stacks/apps/paperless/docker-compose.yml": DECLARED,
             "stacks/reverse-proxy/docker-compose.yml": "services: {}\n",
         })
         assert run("check-deps") == 0
 
-    def test_a_tree_that_does_not_check_out_exits_one(self, run, filesystem, caplog):
+    def test_check_deps_exits_one_for_a_tree_that_does_not_check_out(self, run, filesystem, caplog):
         filesystem.files["stacks/apps/gamarr/docker-compose.yml"] = (
             "x-homelab:\n    requires: [romm]\nservices: {}\n"
         )

--- a/tools/ci/tests/unit/test_cluster.py
+++ b/tools/ci/tests/unit/test_cluster.py
@@ -19,17 +19,6 @@ STACK_LS = ["docker", "stack", "ls", "--format", "{{.Name}}"]
 SERVICE_LS = ["docker", "service", "ls", "--format", "{{.Name}}\t{{.Replicas}}"]
 
 
-@pytest.fixture
-def subject(container, commands):
-    """The cluster under test, over what `stack ls` / `service ls` are made to report."""
-
-    def _subject(stacks: str = "", services: str = "") -> SwarmCluster:
-        responds(commands, CommandResult(0, stacks), CommandResult(0, services))
-        return container.cluster()
-
-    return _subject
-
-
 def test_parse_replicas_reads_running_over_desired():
     assert parse_replicas("2/3") == (2, 3)
 
@@ -45,6 +34,16 @@ def test_parse_replicas_never_reports_an_unreadable_column_as_converged():
 
 class TestSwarmCluster:
     """`SwarmCluster` — what the cluster says exists, and what has converged."""
+
+    @pytest.fixture
+    def subject(self, container, commands):
+        """The cluster under test, over what `stack ls` / `service ls` report."""
+
+        def _subject(stacks: str = "", services: str = "") -> SwarmCluster:
+            responds(commands, CommandResult(0, stacks), CommandResult(0, services))
+            return container.cluster()
+
+        return _subject
 
     def test_a_stack_not_listed_is_absent(self, subject):
         cluster = subject(stacks="authentik\n", services="authentik_server\t1/1\n")

--- a/tools/ci/tests/unit/test_cluster.py
+++ b/tools/ci/tests/unit/test_cluster.py
@@ -45,29 +45,29 @@ class TestSwarmCluster:
 
         return _subject
 
-    def test_a_stack_not_listed_is_absent(self, subject):
+    def test_state_a_stack_not_listed_is_absent(self, subject):
         cluster = subject(stacks="authentik\n", services="authentik_server\t1/1\n")
         assert cluster.state("paperless") is StackState.ABSENT
 
-    def test_every_service_at_its_desired_replicas_is_converged(self, subject):
+    def test_state_every_service_at_its_desired_replicas_is_converged(self, subject):
         cluster = subject(
             stacks="paperless\n",
             services="paperless_web\t1/1\npaperless_db\t2/2\n",
         )
         assert cluster.state("paperless") is StackState.CONVERGED
 
-    def test_a_single_service_short_of_desired_leaves_the_stack_present(self, subject):
+    def test_state_a_single_service_short_of_desired_leaves_the_stack_present(self, subject):
         cluster = subject(
             stacks="paperless\n",
             services="paperless_web\t1/1\npaperless_db\t0/1\n",
         )
         assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_a_listed_stack_with_no_services_yet_is_present_not_converged(self, subject):
+    def test_state_a_listed_stack_with_no_services_yet_is_present(self, subject):
         cluster = subject(stacks="paperless\n", services="")
         assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_a_service_is_attributed_to_the_longest_stack_name_that_prefixes_it(self, subject):
+    def test_state_attributes_a_service_to_the_longest_stack_name_prefixing_it(self, subject):
         cluster = subject(
             stacks="actual\nactual_server\n",
             services="actual_web\t1/1\nactual_server_actual_mcp\t0/1\n",
@@ -75,22 +75,22 @@ class TestSwarmCluster:
         assert cluster.state("actual") is StackState.CONVERGED
         assert cluster.state("actual_server") is StackState.PRESENT
 
-    def test_a_service_belonging_to_no_listed_stack_is_ignored(self, subject):
+    def test_state_ignores_a_service_belonging_to_no_listed_stack(self, subject):
         cluster = subject(stacks="paperless\n", services="orphan_svc\t0/1\n")
         assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_it_only_ever_lists(self, subject, commands):
+    def test_states_only_ever_lists(self, subject, commands):
         subject(stacks="paperless\n", services="paperless_web\t1/1\n").states()
         assert argvs(commands) == [STACK_LS, SERVICE_LS]
 
-    def test_the_cluster_is_read_once_however_many_stacks_are_asked_about(self, subject, commands):
+    def test_state_reads_the_cluster_once_however_many_stacks_are_asked_about(self, subject, commands):
         cluster = subject(stacks="a\nb\n", services="a_x\t1/1\nb_y\t1/1\n")
         cluster.state("a")
         cluster.state("b")
         cluster.state("c")
         assert argvs(commands) == [STACK_LS, SERVICE_LS]
 
-    def test_an_unreachable_cluster_fails_naming_the_command_and_its_error(self, subject, commands):
+    def test_states_an_unreachable_cluster_fails_naming_the_command_and_its_error(self, subject, commands):
         cluster = subject()
         responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
         with pytest.raises(ClusterUnreachable) as exc:

--- a/tools/ci/tests/unit/test_cluster.py
+++ b/tools/ci/tests/unit/test_cluster.py
@@ -19,9 +19,15 @@ STACK_LS = ["docker", "stack", "ls", "--format", "{{.Name}}"]
 SERVICE_LS = ["docker", "service", "ls", "--format", "{{.Name}}\t{{.Replicas}}"]
 
 
-def cluster(commands, stacks: str = "", services: str = "") -> SwarmCluster:
-    responds(commands, CommandResult(0, stacks), CommandResult(0, services))
-    return SwarmCluster(commands)
+@pytest.fixture
+def subject(container, commands):
+    """The cluster under test, over what `stack ls` / `service ls` are made to report."""
+
+    def _subject(stacks: str = "", services: str = "") -> SwarmCluster:
+        responds(commands, CommandResult(0, stacks), CommandResult(0, services))
+        return container.cluster()
+
+    return _subject
 
 
 def test_parse_replicas_reads_running_over_desired():
@@ -40,57 +46,55 @@ def test_parse_replicas_never_reports_an_unreadable_column_as_converged():
 class TestSwarmCluster:
     """`SwarmCluster` — what the cluster says exists, and what has converged."""
 
-    def test_a_stack_not_listed_is_absent(self, commands):
-        subject = cluster(commands, stacks="authentik\n", services="authentik_server|1/1\n".replace("|", "\t"))
-        assert subject.state("paperless") is StackState.ABSENT
+    def test_a_stack_not_listed_is_absent(self, subject):
+        cluster = subject(stacks="authentik\n", services="authentik_server\t1/1\n")
+        assert cluster.state("paperless") is StackState.ABSENT
 
-    def test_every_service_at_its_desired_replicas_is_converged(self, commands):
-        subject = cluster(
-            commands,
+    def test_every_service_at_its_desired_replicas_is_converged(self, subject):
+        cluster = subject(
             stacks="paperless\n",
             services="paperless_web\t1/1\npaperless_db\t2/2\n",
         )
-        assert subject.state("paperless") is StackState.CONVERGED
+        assert cluster.state("paperless") is StackState.CONVERGED
 
-    def test_a_single_service_short_of_desired_leaves_the_stack_present(self, commands):
-        subject = cluster(
-            commands,
+    def test_a_single_service_short_of_desired_leaves_the_stack_present(self, subject):
+        cluster = subject(
             stacks="paperless\n",
             services="paperless_web\t1/1\npaperless_db\t0/1\n",
         )
-        assert subject.state("paperless") is StackState.PRESENT
+        assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_a_listed_stack_with_no_services_yet_is_present_not_converged(self, commands):
-        subject = cluster(commands, stacks="paperless\n", services="")
-        assert subject.state("paperless") is StackState.PRESENT
+    def test_a_listed_stack_with_no_services_yet_is_present_not_converged(self, subject):
+        cluster = subject(stacks="paperless\n", services="")
+        assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_a_service_is_attributed_to_the_longest_stack_name_that_prefixes_it(self, commands):
-        subject = cluster(
-            commands,
+    def test_a_service_is_attributed_to_the_longest_stack_name_that_prefixes_it(self, subject):
+        cluster = subject(
             stacks="actual\nactual_server\n",
             services="actual_web\t1/1\nactual_server_actual_mcp\t0/1\n",
         )
-        assert subject.state("actual") is StackState.CONVERGED
-        assert subject.state("actual_server") is StackState.PRESENT
+        assert cluster.state("actual") is StackState.CONVERGED
+        assert cluster.state("actual_server") is StackState.PRESENT
 
-    def test_a_service_belonging_to_no_listed_stack_is_ignored(self, commands):
-        subject = cluster(commands, stacks="paperless\n", services="orphan_svc\t0/1\n")
-        assert subject.state("paperless") is StackState.PRESENT
+    def test_a_service_belonging_to_no_listed_stack_is_ignored(self, subject):
+        cluster = subject(stacks="paperless\n", services="orphan_svc\t0/1\n")
+        assert cluster.state("paperless") is StackState.PRESENT
 
-    def test_it_only_ever_lists(self, commands):
-        cluster(commands, stacks="paperless\n", services="paperless_web\t1/1\n").states()
+    def test_it_only_ever_lists(self, subject, commands):
+        subject(stacks="paperless\n", services="paperless_web\t1/1\n").states()
         assert argvs(commands) == [STACK_LS, SERVICE_LS]
 
-    def test_the_cluster_is_read_once_however_many_stacks_are_asked_about(self, commands):
-        subject = cluster(commands, stacks="a\nb\n", services="a_x\t1/1\nb_y\t1/1\n")
-        subject.state("a")
-        subject.state("b")
-        subject.state("c")
+    def test_the_cluster_is_read_once_however_many_stacks_are_asked_about(self, subject, commands):
+        cluster = subject(stacks="a\nb\n", services="a_x\t1/1\nb_y\t1/1\n")
+        cluster.state("a")
+        cluster.state("b")
+        cluster.state("c")
         assert argvs(commands) == [STACK_LS, SERVICE_LS]
 
-    def test_an_unreachable_cluster_fails_naming_the_command_and_its_error(self, commands):
+    def test_an_unreachable_cluster_fails_naming_the_command_and_its_error(self, subject, commands):
+        cluster = subject()
         responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
         with pytest.raises(ClusterUnreachable) as exc:
-            SwarmCluster(commands).states()
+            cluster.states()
         assert "docker stack ls" in str(exc.value)
         assert "Cannot connect to the Docker daemon" in str(exc.value)

--- a/tools/ci/tests/unit/test_cluster.py
+++ b/tools/ci/tests/unit/test_cluster.py
@@ -1,0 +1,96 @@
+"""Tests for the live Swarm state a plan reports (`ci.cluster`).
+
+The dangerous case is calling a stack CONVERGED when it is not — a plan that
+says so is a plan that skips work the cluster still needs. Every read goes
+through the command boundary, so these assert the exact argv as well as the
+verdict: `--plan` must only ever list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import argvs, responds
+
+from ci.adapters import CommandResult
+from ci.cluster import ClusterUnreachable, StackState, SwarmCluster, parse_replicas
+
+STACK_LS = ["docker", "stack", "ls", "--format", "{{.Name}}"]
+SERVICE_LS = ["docker", "service", "ls", "--format", "{{.Name}}\t{{.Replicas}}"]
+
+
+def cluster(commands, stacks: str = "", services: str = "") -> SwarmCluster:
+    responds(commands, CommandResult(0, stacks), CommandResult(0, services))
+    return SwarmCluster(commands)
+
+
+def test_parse_replicas_reads_running_over_desired():
+    assert parse_replicas("2/3") == (2, 3)
+
+
+def test_parse_replicas_ignores_the_placement_suffix_swarm_appends():
+    assert parse_replicas("1/1 (max 1 per node)") == (1, 1)
+
+
+def test_parse_replicas_never_reports_an_unreadable_column_as_converged():
+    running, desired = parse_replicas("?")
+    assert running != desired
+
+
+class TestSwarmCluster:
+    """`SwarmCluster` — what the cluster says exists, and what has converged."""
+
+    def test_a_stack_not_listed_is_absent(self, commands):
+        subject = cluster(commands, stacks="authentik\n", services="authentik_server|1/1\n".replace("|", "\t"))
+        assert subject.state("paperless") is StackState.ABSENT
+
+    def test_every_service_at_its_desired_replicas_is_converged(self, commands):
+        subject = cluster(
+            commands,
+            stacks="paperless\n",
+            services="paperless_web\t1/1\npaperless_db\t2/2\n",
+        )
+        assert subject.state("paperless") is StackState.CONVERGED
+
+    def test_a_single_service_short_of_desired_leaves_the_stack_present(self, commands):
+        subject = cluster(
+            commands,
+            stacks="paperless\n",
+            services="paperless_web\t1/1\npaperless_db\t0/1\n",
+        )
+        assert subject.state("paperless") is StackState.PRESENT
+
+    def test_a_listed_stack_with_no_services_yet_is_present_not_converged(self, commands):
+        subject = cluster(commands, stacks="paperless\n", services="")
+        assert subject.state("paperless") is StackState.PRESENT
+
+    def test_a_service_is_attributed_to_the_longest_stack_name_that_prefixes_it(self, commands):
+        subject = cluster(
+            commands,
+            stacks="actual\nactual_server\n",
+            services="actual_web\t1/1\nactual_server_actual_mcp\t0/1\n",
+        )
+        assert subject.state("actual") is StackState.CONVERGED
+        assert subject.state("actual_server") is StackState.PRESENT
+
+    def test_a_service_belonging_to_no_listed_stack_is_ignored(self, commands):
+        subject = cluster(commands, stacks="paperless\n", services="orphan_svc\t0/1\n")
+        assert subject.state("paperless") is StackState.PRESENT
+
+    def test_it_only_ever_lists(self, commands):
+        cluster(commands, stacks="paperless\n", services="paperless_web\t1/1\n").states()
+        assert argvs(commands) == [STACK_LS, SERVICE_LS]
+
+    def test_the_cluster_is_read_once_however_many_stacks_are_asked_about(self, commands):
+        subject = cluster(commands, stacks="a\nb\n", services="a_x\t1/1\nb_y\t1/1\n")
+        subject.state("a")
+        subject.state("b")
+        subject.state("c")
+        assert argvs(commands) == [STACK_LS, SERVICE_LS]
+
+    def test_an_unreachable_cluster_fails_naming_the_command_and_its_error(self, commands):
+        responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
+        with pytest.raises(ClusterUnreachable) as exc:
+            SwarmCluster(commands).states()
+        assert "docker stack ls" in str(exc.value)
+        assert "Cannot connect to the Docker daemon" in str(exc.value)

--- a/tools/ci/tests/unit/test_containers.py
+++ b/tools/ci/tests/unit/test_containers.py
@@ -1,0 +1,67 @@
+"""The composition root's own contract: lifetimes, and refusing to run half-wired.
+
+Lifetime is not cosmetic here. `SwarmCluster` caches the cluster read so a plan
+over 54 stacks costs two docker calls; rebuilt per resolution it would cost two
+per resolution. And a container missing its repo root or environment must say
+so, rather than resolving to a default that silently reads the wrong tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dependency_injector import errors, providers
+
+from conftest import ROOT
+
+from ci.containers import Container
+
+
+@pytest.fixture
+def subject() -> Container:
+    c = Container()
+    c.repo_root.override(providers.Object(str(ROOT)))
+    c.env.override(providers.Object({}))
+    return c
+
+
+class TestLifetimes:
+    """Which providers are shared, and which are rebuilt."""
+
+    def test_an_adapter_is_shared_because_it_holds_no_state_worth_rebuilding(self, subject):
+        assert subject.filesystem() is subject.filesystem()
+
+    def test_the_cluster_is_shared_so_one_invocation_reads_the_cluster_once(self, subject):
+        assert subject.cluster() is subject.cluster()
+
+    def test_a_service_is_rebuilt_so_it_closes_over_this_run_s_configuration(self, subject):
+        assert subject.graph() is not subject.graph()
+
+
+class TestRequiredConfiguration:
+    """A container that was not told where it is, or what is switched on."""
+
+    def test_a_container_without_a_repo_root_refuses_to_build_a_service(self):
+        container = Container()
+        container.env.override(providers.Object({}))
+        with pytest.raises(errors.Error):
+            container.graph()
+
+    def test_a_container_without_an_environment_refuses_to_build_a_service(self):
+        container = Container()
+        container.repo_root.override(providers.Object(str(ROOT)))
+        with pytest.raises(errors.Error):
+            container.graph()
+
+    def test_a_repo_root_that_is_not_a_path_is_rejected(self):
+        container = Container()
+        with pytest.raises(errors.Error):
+            container.repo_root.override(providers.Object(object()))
+            container.env.override(providers.Object({}))
+            container.graph()
+
+    def test_an_environment_that_is_not_a_mapping_is_rejected(self):
+        container = Container()
+        with pytest.raises(errors.Error):
+            container.repo_root.override(providers.Object(str(ROOT)))
+            container.env.override(providers.Object("PRIMARY_DNS_MANAGED=false"))
+            container.graph()

--- a/tools/ci/tests/unit/test_containers.py
+++ b/tools/ci/tests/unit/test_containers.py
@@ -26,35 +26,35 @@ class TestContainer:
         c.env.override(providers.Object({}))
         return c
 
-    def test_an_adapter_is_shared_because_it_holds_no_state_worth_rebuilding(self, subject):
+    def test_filesystem_is_shared_because_it_holds_no_state_worth_rebuilding(self, subject):
         assert subject.filesystem() is subject.filesystem()
 
-    def test_the_cluster_is_shared_so_one_invocation_reads_the_cluster_once(self, subject):
+    def test_cluster_is_shared_so_one_invocation_reads_the_cluster_once(self, subject):
         assert subject.cluster() is subject.cluster()
 
-    def test_a_service_is_rebuilt_so_it_closes_over_this_run_s_configuration(self, subject):
+    def test_graph_is_rebuilt_so_it_closes_over_this_runs_configuration(self, subject):
         assert subject.graph() is not subject.graph()
 
-    def test_a_container_without_a_repo_root_refuses_to_build_a_service(self):
+    def test_repo_root_is_required_before_any_service_can_be_built(self):
         container = Container()
         container.env.override(providers.Object({}))
         with pytest.raises(errors.Error):
             container.graph()
 
-    def test_a_container_without_an_environment_refuses_to_build_a_service(self):
+    def test_env_is_required_before_any_service_can_be_built(self):
         container = Container()
         container.repo_root.override(providers.Object(str(ROOT)))
         with pytest.raises(errors.Error):
             container.graph()
 
-    def test_a_repo_root_that_is_not_a_path_is_rejected(self):
+    def test_repo_root_rejects_a_value_that_is_not_a_string(self):
         container = Container()
         with pytest.raises(errors.Error):
             container.repo_root.override(providers.Object(object()))
             container.env.override(providers.Object({}))
             container.graph()
 
-    def test_an_environment_that_is_not_a_mapping_is_rejected(self):
+    def test_env_rejects_a_value_that_is_not_a_mapping(self):
         container = Container()
         with pytest.raises(errors.Error):
             container.repo_root.override(providers.Object(str(ROOT)))

--- a/tools/ci/tests/unit/test_containers.py
+++ b/tools/ci/tests/unit/test_containers.py
@@ -16,16 +16,15 @@ from conftest import ROOT
 from ci.containers import Container
 
 
-@pytest.fixture
-def subject() -> Container:
-    c = Container()
-    c.repo_root.override(providers.Object(str(ROOT)))
-    c.env.override(providers.Object({}))
-    return c
+class TestContainer:
+    """`Container` — which providers are shared, and what it refuses to build."""
 
-
-class TestLifetimes:
-    """Which providers are shared, and which are rebuilt."""
+    @pytest.fixture
+    def subject(self) -> Container:
+        c = Container()
+        c.repo_root.override(providers.Object(str(ROOT)))
+        c.env.override(providers.Object({}))
+        return c
 
     def test_an_adapter_is_shared_because_it_holds_no_state_worth_rebuilding(self, subject):
         assert subject.filesystem() is subject.filesystem()
@@ -35,10 +34,6 @@ class TestLifetimes:
 
     def test_a_service_is_rebuilt_so_it_closes_over_this_run_s_configuration(self, subject):
         assert subject.graph() is not subject.graph()
-
-
-class TestRequiredConfiguration:
-    """A container that was not told where it is, or what is switched on."""
 
     def test_a_container_without_a_repo_root_refuses_to_build_a_service(self):
         container = Container()

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -31,11 +31,6 @@ TREE = {
 }
 
 
-def by_stack(rows: list[PlanRow]) -> dict[str, PlanRow]:
-    """Rows keyed by name, so an assertion names the stack it is about."""
-    return {row.stack: row for row in rows}
-
-
 class TestDeployPlanner:
     """`DeployPlanner` — the plan it builds, and the plan it prints."""
 
@@ -53,66 +48,44 @@ class TestDeployPlanner:
 
         return _live
 
-    # --- the rows it builds -------------------------------------------------
+    # --- the plan it builds -------------------------------------------------
 
-    def test_a_stack_absent_from_the_cluster_reports_absent(self, subject, live):
-        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = by_stack(subject.rows(["paperless"]))
-        assert rows["paperless"].state is StackState.ABSENT
-        assert rows["authentik"].state is StackState.ABSENT
-
-    def test_a_stack_at_its_desired_replicas_reports_converged(self, subject, live):
-        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = by_stack(subject.rows(["paperless"]))
-        assert rows["reverse-proxy"].state is StackState.CONVERGED
-
-    def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, subject, live):
-        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t0/1\n")
-        rows = by_stack(subject.rows(["paperless"]))
-        assert rows["reverse-proxy"].state is StackState.PRESENT
-
-    def test_rows_come_in_deploy_order(self, subject, live):
-        live()
-        assert [row.stack for row in subject.rows(["paperless"])] == [
-            "reverse-proxy",
-            "authentik",
-            "paperless",
+    def test_a_target_pulls_in_its_chain_each_row_carrying_its_live_state(
+        self, subject, live
+    ):
+        """One assertion for the whole plan: order, state, and why each row is there."""
+        live(
+            stacks="reverse-proxy\nauthentik\n",
+            services="reverse-proxy_traefik\t1/1\nauthentik_server\t0/1\n",
+        )
+        assert subject.rows(["paperless"]) == [
+            PlanRow("reverse-proxy", StackState.CONVERGED, Origin.DEPENDENCY, ("paperless",)),
+            PlanRow("authentik", StackState.PRESENT, Origin.DEPENDENCY, ("paperless",)),
+            PlanRow("paperless", StackState.ABSENT, Origin.TARGET),
         ]
 
-    # --- why each row is in the plan ----------------------------------------
-
-    def test_an_explicit_target_says_so(self, subject, live):
+    def test_a_shared_dependency_names_every_target_and_a_named_target_stays_one(
+        self, subject, live
+    ):
         live()
-        row = by_stack(subject.rows(["paperless"]))["paperless"]
-        assert row.origin is Origin.TARGET
-        assert row.required_by == ()
-
-    def test_a_dependency_names_the_target_that_required_it(self, subject, live):
-        live()
-        row = by_stack(subject.rows(["paperless"]))["authentik"]
-        assert row.origin is Origin.DEPENDENCY
-        assert row.required_by == ("paperless",)
-
-    def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, subject, live):
-        live()
-        rows = by_stack(subject.rows(["paperless"]))
-        assert rows["reverse-proxy"].required_by == ("paperless",)
-
-    def test_a_dependency_of_several_targets_names_them_all(self, subject, live):
-        live()
-        rows = by_stack(subject.rows(["paperless", "authentik"]))
-        assert rows["reverse-proxy"].required_by == ("authentik", "paperless")
-
-    def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, subject, live):
-        live()
-        rows = by_stack(subject.rows(["paperless", "authentik"]))
-        assert rows["authentik"].origin is Origin.TARGET
-        assert rows["authentik"].required_by == ()
+        assert subject.rows(["paperless", "authentik"]) == [
+            PlanRow(
+                "reverse-proxy",
+                StackState.ABSENT,
+                Origin.DEPENDENCY,
+                ("authentik", "paperless"),
+            ),
+            PlanRow("authentik", StackState.ABSENT, Origin.TARGET),
+            PlanRow("paperless", StackState.ABSENT, Origin.TARGET),
+        ]
 
     def test_a_full_plan_has_no_target_to_attribute_rows_to(self, subject, live):
         live()
-        assert {row.origin for row in subject.rows(None)} == {Origin.WHOLE_TREE}
-        assert {row.required_by for row in subject.rows(None)} == {()}
+        assert subject.rows(None) == [
+            PlanRow("reverse-proxy", StackState.ABSENT, Origin.WHOLE_TREE),
+            PlanRow("authentik", StackState.ABSENT, Origin.WHOLE_TREE),
+            PlanRow("paperless", StackState.ABSENT, Origin.WHOLE_TREE),
+        ]
 
     def test_it_reads_the_tree_once_though_it_asks_the_graph_twice(
         self, subject, live, filesystem

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -103,6 +103,14 @@ class TestDeployPlanRows:
         assert {row.reason for row in subject.rows(None)} == {""}
         assert {row.verb for row in subject.rows(None)} == {"deploy"}
 
+    def test_it_reads_the_tree_once_though_it_asks_the_graph_twice(
+        self, subject, live, filesystem
+    ):
+        """Order and attribution are two questions; the compose files are read for both."""
+        live()
+        subject.rows(["paperless"])
+        assert len(filesystem.reads) == len(TREE)
+
     def test_rows_come_in_deploy_order(self, subject, live):
         live()
         assert [row.stack for row in subject.rows(["paperless"])] == [

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -1,0 +1,159 @@
+"""Tests for the deploy plan (`ci.deploy`) — order plus live state, printed.
+
+A plan is only useful if it says what will happen rather than listing
+everything, so the assertions here are about the two things that distinguish
+the rows: the state each stack is already in, and why it is in the plan at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import argvs, responds
+
+from ci.adapters import CommandResult
+from ci.cluster import StackState
+
+LABELS = 'services:\n    a:\n        deploy:\n            labels: [{}]\n'
+TRAEFIK = LABELS.format('"traefik.enable=true"')
+PROXY = "services: {}\n"
+NEEDS_PROXY = "x-homelab:\n    requires: [reverse-proxy]\n" + TRAEFIK
+NEEDS_AUTH = "x-homelab:\n    requires: [reverse-proxy, authentik]\n" + LABELS.format(
+    '"traefik.enable=true", "traefik.http.routers.p.middlewares=authentik@swarm"'
+)
+
+TREE = {
+    "stacks/reverse-proxy/docker-compose.yml": PROXY,
+    "stacks/apps/authentik/docker-compose.yml": NEEDS_PROXY,
+    "stacks/apps/paperless/docker-compose.yml": NEEDS_AUTH,
+}
+
+
+@pytest.fixture
+def tree(filesystem):
+    filesystem.files.update(TREE)
+    return filesystem
+
+
+@pytest.fixture
+def live(commands):
+    """Seed what the cluster reports: stack names, then `service<TAB>replicas`."""
+
+    def _live(stacks: str = "", services: str = "") -> None:
+        responds(commands, CommandResult(0, stacks), CommandResult(0, services))
+
+    return _live
+
+
+@pytest.fixture
+def plan(container, tree):
+    return container.deploy_plan()
+
+
+def rows_by_stack(rows):
+    return {row.stack: row for row in rows}
+
+
+class TestDeployPlanRows:
+    """`DeployPlan.rows` — one row per stack the deploy would touch."""
+
+    def test_a_stack_absent_from_the_cluster_reports_absent(self, plan, live):
+        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
+        rows = rows_by_stack(plan.rows(["paperless"]))
+        assert rows["paperless"].state is StackState.ABSENT
+        assert rows["authentik"].state is StackState.ABSENT
+
+    def test_a_stack_at_its_desired_replicas_reports_converged(self, plan, live):
+        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
+        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].state is StackState.CONVERGED
+
+    def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, plan, live):
+        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t0/1\n")
+        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].state is StackState.PRESENT
+
+    def test_an_explicit_target_says_so(self, plan, live):
+        live()
+        row = rows_by_stack(plan.rows(["paperless"]))["paperless"]
+        assert row.verb == "deploy"
+        assert row.reason == "explicit target"
+
+    def test_a_dependency_names_the_target_that_required_it(self, plan, live):
+        live()
+        row = rows_by_stack(plan.rows(["paperless"]))["authentik"]
+        assert row.verb == "ensure"
+        assert row.reason == "required by paperless"
+
+    def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, plan, live):
+        live()
+        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].reason == "required by paperless"
+
+    def test_a_dependency_of_several_targets_names_them_all(self, plan, live):
+        live()
+        rows = rows_by_stack(plan.rows(["paperless", "authentik"]))
+        assert rows["reverse-proxy"].reason == "required by authentik, paperless"
+
+    def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, plan, live):
+        live()
+        rows = rows_by_stack(plan.rows(["paperless", "authentik"]))
+        assert rows["authentik"].verb == "deploy"
+        assert rows["authentik"].reason == "explicit target"
+
+    def test_a_full_plan_has_no_target_to_attribute_rows_to(self, plan, live):
+        live()
+        assert {row.reason for row in plan.rows(None)} == {""}
+        assert {row.verb for row in plan.rows(None)} == {"deploy"}
+
+    def test_rows_come_in_deploy_order(self, plan, live):
+        live()
+        assert [row.stack for row in plan.rows(["paperless"])] == [
+            "reverse-proxy",
+            "authentik",
+            "paperless",
+        ]
+
+
+class TestDeployPlanReport:
+    """`DeployPlan.report` — the printed plan, and what it refuses to do."""
+
+    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, plan, live, console):
+        live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
+        assert plan.report(["paperless"]) == 0
+        assert [" ".join(line.split()) for line in console.stdout] == [
+            "ensure reverse-proxy converged → required by paperless",
+            "ensure authentik absent → required by paperless",
+            "deploy paperless absent → explicit target",
+        ]
+
+    def test_the_columns_line_up_so_the_states_can_be_scanned(self, plan, live, console):
+        live()
+        plan.report(["paperless"])
+        assert len({line.index("→") for line in console.stdout}) == 1
+
+    def test_the_count_goes_to_stderr_so_stdout_stays_pipeable(self, plan, live, console):
+        live()
+        plan.report(["paperless"])
+        assert "3 stack(s) — plan only, nothing deployed." in "\n".join(console.stderr)
+
+    def test_it_only_ever_lists(self, plan, live, commands):
+        live()
+        plan.report(None)
+        assert [argv[:3] for argv in argvs(commands)] == [
+            ["docker", "stack", "ls"],
+            ["docker", "service", "ls"],
+        ]
+
+    def test_an_unresolvable_graph_exits_one_before_touching_the_cluster(
+        self, plan, filesystem, console, commands
+    ):
+        filesystem.files["stacks/apps/ghost/docker-compose.yml"] = (
+            "x-homelab:\n    requires: [nope]\nservices: {}\n"
+        )
+        assert plan.report(None) == 1
+        assert console.stdout == []
+        assert "ghost requires nope" in "\n".join(console.stderr)
+        assert argvs(commands) == []
+
+    def test_an_unreachable_cluster_exits_one_and_explains(self, plan, commands, console):
+        responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
+        assert plan.report(None) == 1
+        assert "Cannot connect to the Docker daemon" in "\n".join(console.stderr)

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -46,7 +46,7 @@ def live(commands):
 
 
 @pytest.fixture
-def plan(container, tree):
+def subject(container, tree):
     return container.deploy_plan()
 
 
@@ -57,55 +57,55 @@ def rows_by_stack(rows):
 class TestDeployPlanRows:
     """`DeployPlan.rows` — one row per stack the deploy would touch."""
 
-    def test_a_stack_absent_from_the_cluster_reports_absent(self, plan, live):
+    def test_a_stack_absent_from_the_cluster_reports_absent(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = rows_by_stack(plan.rows(["paperless"]))
+        rows = rows_by_stack(subject.rows(["paperless"]))
         assert rows["paperless"].state is StackState.ABSENT
         assert rows["authentik"].state is StackState.ABSENT
 
-    def test_a_stack_at_its_desired_replicas_reports_converged(self, plan, live):
+    def test_a_stack_at_its_desired_replicas_reports_converged(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].state is StackState.CONVERGED
+        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].state is StackState.CONVERGED
 
-    def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, plan, live):
+    def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t0/1\n")
-        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].state is StackState.PRESENT
+        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].state is StackState.PRESENT
 
-    def test_an_explicit_target_says_so(self, plan, live):
+    def test_an_explicit_target_says_so(self, subject, live):
         live()
-        row = rows_by_stack(plan.rows(["paperless"]))["paperless"]
+        row = rows_by_stack(subject.rows(["paperless"]))["paperless"]
         assert row.verb == "deploy"
         assert row.reason == "explicit target"
 
-    def test_a_dependency_names_the_target_that_required_it(self, plan, live):
+    def test_a_dependency_names_the_target_that_required_it(self, subject, live):
         live()
-        row = rows_by_stack(plan.rows(["paperless"]))["authentik"]
+        row = rows_by_stack(subject.rows(["paperless"]))["authentik"]
         assert row.verb == "ensure"
         assert row.reason == "required by paperless"
 
-    def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, plan, live):
+    def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, subject, live):
         live()
-        assert rows_by_stack(plan.rows(["paperless"]))["reverse-proxy"].reason == "required by paperless"
+        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].reason == "required by paperless"
 
-    def test_a_dependency_of_several_targets_names_them_all(self, plan, live):
+    def test_a_dependency_of_several_targets_names_them_all(self, subject, live):
         live()
-        rows = rows_by_stack(plan.rows(["paperless", "authentik"]))
+        rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["reverse-proxy"].reason == "required by authentik, paperless"
 
-    def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, plan, live):
+    def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, subject, live):
         live()
-        rows = rows_by_stack(plan.rows(["paperless", "authentik"]))
+        rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["authentik"].verb == "deploy"
         assert rows["authentik"].reason == "explicit target"
 
-    def test_a_full_plan_has_no_target_to_attribute_rows_to(self, plan, live):
+    def test_a_full_plan_has_no_target_to_attribute_rows_to(self, subject, live):
         live()
-        assert {row.reason for row in plan.rows(None)} == {""}
-        assert {row.verb for row in plan.rows(None)} == {"deploy"}
+        assert {row.reason for row in subject.rows(None)} == {""}
+        assert {row.verb for row in subject.rows(None)} == {"deploy"}
 
-    def test_rows_come_in_deploy_order(self, plan, live):
+    def test_rows_come_in_deploy_order(self, subject, live):
         live()
-        assert [row.stack for row in plan.rows(["paperless"])] == [
+        assert [row.stack for row in subject.rows(["paperless"])] == [
             "reverse-proxy",
             "authentik",
             "paperless",
@@ -115,45 +115,45 @@ class TestDeployPlanRows:
 class TestDeployPlanReport:
     """`DeployPlan.report` — the printed plan, and what it refuses to do."""
 
-    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, plan, live, console):
+    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, console):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        assert plan.report(["paperless"]) == 0
+        assert subject.report(["paperless"]) == 0
         assert [" ".join(line.split()) for line in console.stdout] == [
             "ensure reverse-proxy converged → required by paperless",
             "ensure authentik absent → required by paperless",
             "deploy paperless absent → explicit target",
         ]
 
-    def test_the_columns_line_up_so_the_states_can_be_scanned(self, plan, live, console):
+    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, console):
         live()
-        plan.report(["paperless"])
+        subject.report(["paperless"])
         assert len({line.index("→") for line in console.stdout}) == 1
 
-    def test_the_count_goes_to_stderr_so_stdout_stays_pipeable(self, plan, live, console):
+    def test_the_count_goes_to_stderr_so_stdout_stays_pipeable(self, subject, live, console):
         live()
-        plan.report(["paperless"])
+        subject.report(["paperless"])
         assert "3 stack(s) — plan only, nothing deployed." in "\n".join(console.stderr)
 
-    def test_it_only_ever_lists(self, plan, live, commands):
+    def test_it_only_ever_lists(self, subject, live, commands):
         live()
-        plan.report(None)
+        subject.report(None)
         assert [argv[:3] for argv in argvs(commands)] == [
             ["docker", "stack", "ls"],
             ["docker", "service", "ls"],
         ]
 
     def test_an_unresolvable_graph_exits_one_before_touching_the_cluster(
-        self, plan, filesystem, console, commands
+        self, subject, filesystem, console, commands
     ):
         filesystem.files["stacks/apps/ghost/docker-compose.yml"] = (
             "x-homelab:\n    requires: [nope]\nservices: {}\n"
         )
-        assert plan.report(None) == 1
+        assert subject.report(None) == 1
         assert console.stdout == []
         assert "ghost requires nope" in "\n".join(console.stderr)
         assert argvs(commands) == []
 
-    def test_an_unreachable_cluster_exits_one_and_explains(self, plan, commands, console):
+    def test_an_unreachable_cluster_exits_one_and_explains(self, subject, commands, console):
         responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
-        assert plan.report(None) == 1
+        assert subject.report(None) == 1
         assert "Cannot connect to the Docker daemon" in "\n".join(console.stderr)

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -13,6 +13,7 @@ from conftest import argvs, responds
 
 from ci.adapters import CommandResult
 from ci.cluster import StackState
+from ci.deploy import Origin
 
 LABELS = 'services:\n    a:\n        deploy:\n            labels: [{}]\n'
 TRAEFIK = LABELS.format('"traefik.enable=true"')
@@ -74,34 +75,34 @@ class TestDeployPlanRows:
     def test_an_explicit_target_says_so(self, subject, live):
         live()
         row = rows_by_stack(subject.rows(["paperless"]))["paperless"]
-        assert row.verb == "deploy"
-        assert row.reason == "explicit target"
+        assert row.origin is Origin.TARGET
+        assert row.required_by == ()
 
     def test_a_dependency_names_the_target_that_required_it(self, subject, live):
         live()
         row = rows_by_stack(subject.rows(["paperless"]))["authentik"]
-        assert row.verb == "ensure"
-        assert row.reason == "required by paperless"
+        assert row.origin is Origin.DEPENDENCY
+        assert row.required_by == ("paperless",)
 
     def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, subject, live):
         live()
-        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].reason == "required by paperless"
+        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].required_by == ("paperless",)
 
     def test_a_dependency_of_several_targets_names_them_all(self, subject, live):
         live()
         rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
-        assert rows["reverse-proxy"].reason == "required by authentik, paperless"
+        assert rows["reverse-proxy"].required_by == ("authentik", "paperless")
 
     def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, subject, live):
         live()
         rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
-        assert rows["authentik"].verb == "deploy"
-        assert rows["authentik"].reason == "explicit target"
+        assert rows["authentik"].origin is Origin.TARGET
+        assert rows["authentik"].required_by == ()
 
     def test_a_full_plan_has_no_target_to_attribute_rows_to(self, subject, live):
         live()
-        assert {row.reason for row in subject.rows(None)} == {""}
-        assert {row.verb for row in subject.rows(None)} == {"deploy"}
+        assert {row.origin for row in subject.rows(None)} == {Origin.WHOLE_TREE}
+        assert {row.required_by for row in subject.rows(None)} == {()}
 
     def test_it_reads_the_tree_once_though_it_asks_the_graph_twice(
         self, subject, live, filesystem

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -13,7 +13,7 @@ from conftest import argvs, responds
 
 from ci.adapters import CommandResult
 from ci.cluster import StackState
-from ci.deploy import Origin
+from ci.deploy import Origin, PlanRow
 
 LABELS = 'services:\n    a:\n        deploy:\n            labels: [{}]\n'
 TRAEFIK = LABELS.format('"traefik.enable=true"')
@@ -29,6 +29,11 @@ TREE = {
     "stacks/apps/authentik/docker-compose.yml": NEEDS_PROXY,
     "stacks/apps/paperless/docker-compose.yml": NEEDS_AUTH,
 }
+
+
+def by_stack(rows: list[PlanRow]) -> dict[str, PlanRow]:
+    """Rows keyed by name, so an assertion names the stack it is about."""
+    return {row.stack: row for row in rows}
 
 
 class TestDeployPlanner:
@@ -48,25 +53,22 @@ class TestDeployPlanner:
 
         return _live
 
-    def _by_stack(self, rows):
-        return {row.stack: row for row in rows}
-
     # --- the rows it builds -------------------------------------------------
 
     def test_a_stack_absent_from_the_cluster_reports_absent(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = self._by_stack(subject.rows(["paperless"]))
+        rows = by_stack(subject.rows(["paperless"]))
         assert rows["paperless"].state is StackState.ABSENT
         assert rows["authentik"].state is StackState.ABSENT
 
     def test_a_stack_at_its_desired_replicas_reports_converged(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = self._by_stack(subject.rows(["paperless"]))
+        rows = by_stack(subject.rows(["paperless"]))
         assert rows["reverse-proxy"].state is StackState.CONVERGED
 
     def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t0/1\n")
-        rows = self._by_stack(subject.rows(["paperless"]))
+        rows = by_stack(subject.rows(["paperless"]))
         assert rows["reverse-proxy"].state is StackState.PRESENT
 
     def test_rows_come_in_deploy_order(self, subject, live):
@@ -81,29 +83,29 @@ class TestDeployPlanner:
 
     def test_an_explicit_target_says_so(self, subject, live):
         live()
-        row = self._by_stack(subject.rows(["paperless"]))["paperless"]
+        row = by_stack(subject.rows(["paperless"]))["paperless"]
         assert row.origin is Origin.TARGET
         assert row.required_by == ()
 
     def test_a_dependency_names_the_target_that_required_it(self, subject, live):
         live()
-        row = self._by_stack(subject.rows(["paperless"]))["authentik"]
+        row = by_stack(subject.rows(["paperless"]))["authentik"]
         assert row.origin is Origin.DEPENDENCY
         assert row.required_by == ("paperless",)
 
     def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, subject, live):
         live()
-        rows = self._by_stack(subject.rows(["paperless"]))
+        rows = by_stack(subject.rows(["paperless"]))
         assert rows["reverse-proxy"].required_by == ("paperless",)
 
     def test_a_dependency_of_several_targets_names_them_all(self, subject, live):
         live()
-        rows = self._by_stack(subject.rows(["paperless", "authentik"]))
+        rows = by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["reverse-proxy"].required_by == ("authentik", "paperless")
 
     def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, subject, live):
         live()
-        rows = self._by_stack(subject.rows(["paperless", "authentik"]))
+        rows = by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["authentik"].origin is Origin.TARGET
         assert rows["authentik"].required_by == ()
 

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -115,24 +115,25 @@ class TestDeployPlanRows:
 class TestDeployPlanReport:
     """`DeployPlan.report` — the printed plan, and what it refuses to do."""
 
-    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, console):
+    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, output):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
         assert subject.report(["paperless"]) == 0
-        assert [" ".join(line.split()) for line in console.stdout] == [
+        assert [" ".join(line.split()) for line in output.lines] == [
             "ensure reverse-proxy converged → required by paperless",
             "ensure authentik absent → required by paperless",
             "deploy paperless absent → explicit target",
         ]
 
-    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, console):
+    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, output):
         live()
         subject.report(["paperless"])
-        assert len({line.index("→") for line in console.stdout}) == 1
+        assert len({line.index("→") for line in output.lines}) == 1
 
-    def test_the_count_goes_to_stderr_so_stdout_stays_pipeable(self, subject, live, console):
+    def test_the_count_is_logged_so_stdout_carries_only_the_plan(self, subject, live, output, caplog):
         live()
         subject.report(["paperless"])
-        assert "3 stack(s) — plan only, nothing deployed." in "\n".join(console.stderr)
+        assert "3 stack(s) — plan only, nothing deployed." in caplog.text
+        assert not any("stack(s)" in line for line in output.lines)
 
     def test_it_only_ever_lists(self, subject, live, commands):
         live()
@@ -143,17 +144,17 @@ class TestDeployPlanReport:
         ]
 
     def test_an_unresolvable_graph_exits_one_before_touching_the_cluster(
-        self, subject, filesystem, console, commands
+        self, subject, filesystem, output, caplog, commands
     ):
         filesystem.files["stacks/apps/ghost/docker-compose.yml"] = (
             "x-homelab:\n    requires: [nope]\nservices: {}\n"
         )
         assert subject.report(None) == 1
-        assert console.stdout == []
-        assert "ghost requires nope" in "\n".join(console.stderr)
+        assert output.lines == []
+        assert "ghost requires nope" in caplog.text
         assert argvs(commands) == []
 
-    def test_an_unreachable_cluster_exits_one_and_explains(self, subject, commands, console):
+    def test_an_unreachable_cluster_exits_one_and_explains(self, subject, commands, caplog):
         responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
         assert subject.report(None) == 1
-        assert "Cannot connect to the Docker daemon" in "\n".join(console.stderr)
+        assert "Cannot connect to the Docker daemon" in caplog.text

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -115,25 +115,25 @@ class TestDeployPlanRows:
 class TestDeployPlanReport:
     """`DeployPlan.report` — the printed plan, and what it refuses to do."""
 
-    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, output):
+    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, capsys):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
         assert subject.report(["paperless"]) == 0
-        assert [" ".join(line.split()) for line in output.lines] == [
+        assert [" ".join(line.split()) for line in capsys.readouterr().out.splitlines()] == [
             "ensure reverse-proxy converged → required by paperless",
             "ensure authentik absent → required by paperless",
             "deploy paperless absent → explicit target",
         ]
 
-    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, output):
+    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, capsys):
         live()
         subject.report(["paperless"])
-        assert len({line.index("→") for line in output.lines}) == 1
+        assert len({line.index("→") for line in capsys.readouterr().out.splitlines()}) == 1
 
-    def test_the_count_is_logged_so_stdout_carries_only_the_plan(self, subject, live, output, caplog):
+    def test_the_count_is_logged_so_stdout_carries_only_the_plan(self, subject, live, capsys, caplog):
         live()
         subject.report(["paperless"])
         assert "3 stack(s) — plan only, nothing deployed." in caplog.text
-        assert not any("stack(s)" in line for line in output.lines)
+        assert "stack(s)" not in capsys.readouterr().out
 
     def test_it_only_ever_lists(self, subject, live, commands):
         live()
@@ -144,13 +144,13 @@ class TestDeployPlanReport:
         ]
 
     def test_an_unresolvable_graph_exits_one_before_touching_the_cluster(
-        self, subject, filesystem, output, caplog, commands
+        self, subject, filesystem, capsys, caplog, commands
     ):
         filesystem.files["stacks/apps/ghost/docker-compose.yml"] = (
             "x-homelab:\n    requires: [nope]\nservices: {}\n"
         )
         assert subject.report(None) == 1
-        assert output.lines == []
+        assert capsys.readouterr().out == ""
         assert "ghost requires nope" in caplog.text
         assert argvs(commands) == []
 

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -1,4 +1,4 @@
-"""Tests for the deploy plan (`ci.deploy`) — order plus live state, printed.
+"""Tests for `ci.deploy.DeployPlanner` — resolved order plus live cluster state.
 
 A plan is only useful if it says what will happen rather than listing
 everything, so the assertions here are about the two things that distinguish
@@ -23,6 +23,7 @@ NEEDS_AUTH = "x-homelab:\n    requires: [reverse-proxy, authentik]\n" + LABELS.f
     '"traefik.enable=true", "traefik.http.routers.p.middlewares=authentik@swarm"'
 )
 
+# paperless → authentik → reverse-proxy, so one target exercises a transitive edge.
 TREE = {
     "stacks/reverse-proxy/docker-compose.yml": PROXY,
     "stacks/apps/authentik/docker-compose.yml": NEEDS_PROXY,
@@ -30,72 +31,79 @@ TREE = {
 }
 
 
-@pytest.fixture
-def tree(filesystem):
-    filesystem.files.update(TREE)
-    return filesystem
+class TestDeployPlanner:
+    """`DeployPlanner` — the plan it builds, and the plan it prints."""
 
+    @pytest.fixture
+    def subject(self, container, filesystem):
+        filesystem.files.update(TREE)
+        return container.planner()
 
-@pytest.fixture
-def live(commands):
-    """Seed what the cluster reports: stack names, then `service<TAB>replicas`."""
+    @pytest.fixture
+    def live(self, commands):
+        """Seed what the cluster reports: stack names, then `service<TAB>replicas`."""
 
-    def _live(stacks: str = "", services: str = "") -> None:
-        responds(commands, CommandResult(0, stacks), CommandResult(0, services))
+        def _live(stacks: str = "", services: str = "") -> None:
+            responds(commands, CommandResult(0, stacks), CommandResult(0, services))
 
-    return _live
+        return _live
 
+    def _by_stack(self, rows):
+        return {row.stack: row for row in rows}
 
-@pytest.fixture
-def subject(container, tree):
-    return container.deploy_plan()
-
-
-def rows_by_stack(rows):
-    return {row.stack: row for row in rows}
-
-
-class TestDeployPlanRows:
-    """`DeployPlan.rows` — one row per stack the deploy would touch."""
+    # --- the rows it builds -------------------------------------------------
 
     def test_a_stack_absent_from_the_cluster_reports_absent(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        rows = rows_by_stack(subject.rows(["paperless"]))
+        rows = self._by_stack(subject.rows(["paperless"]))
         assert rows["paperless"].state is StackState.ABSENT
         assert rows["authentik"].state is StackState.ABSENT
 
     def test_a_stack_at_its_desired_replicas_reports_converged(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
-        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].state is StackState.CONVERGED
+        rows = self._by_stack(subject.rows(["paperless"]))
+        assert rows["reverse-proxy"].state is StackState.CONVERGED
 
     def test_a_stack_deployed_but_short_of_its_replicas_reports_present(self, subject, live):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t0/1\n")
-        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].state is StackState.PRESENT
+        rows = self._by_stack(subject.rows(["paperless"]))
+        assert rows["reverse-proxy"].state is StackState.PRESENT
+
+    def test_rows_come_in_deploy_order(self, subject, live):
+        live()
+        assert [row.stack for row in subject.rows(["paperless"])] == [
+            "reverse-proxy",
+            "authentik",
+            "paperless",
+        ]
+
+    # --- why each row is in the plan ----------------------------------------
 
     def test_an_explicit_target_says_so(self, subject, live):
         live()
-        row = rows_by_stack(subject.rows(["paperless"]))["paperless"]
+        row = self._by_stack(subject.rows(["paperless"]))["paperless"]
         assert row.origin is Origin.TARGET
         assert row.required_by == ()
 
     def test_a_dependency_names_the_target_that_required_it(self, subject, live):
         live()
-        row = rows_by_stack(subject.rows(["paperless"]))["authentik"]
+        row = self._by_stack(subject.rows(["paperless"]))["authentik"]
         assert row.origin is Origin.DEPENDENCY
         assert row.required_by == ("paperless",)
 
     def test_a_transitive_dependency_names_the_target_not_the_middle_stack(self, subject, live):
         live()
-        assert rows_by_stack(subject.rows(["paperless"]))["reverse-proxy"].required_by == ("paperless",)
+        rows = self._by_stack(subject.rows(["paperless"]))
+        assert rows["reverse-proxy"].required_by == ("paperless",)
 
     def test_a_dependency_of_several_targets_names_them_all(self, subject, live):
         live()
-        rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
+        rows = self._by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["reverse-proxy"].required_by == ("authentik", "paperless")
 
     def test_a_target_that_is_also_a_dependency_is_still_an_explicit_target(self, subject, live):
         live()
-        rows = rows_by_stack(subject.rows(["paperless", "authentik"]))
+        rows = self._by_stack(subject.rows(["paperless", "authentik"]))
         assert rows["authentik"].origin is Origin.TARGET
         assert rows["authentik"].required_by == ()
 
@@ -107,22 +115,12 @@ class TestDeployPlanRows:
     def test_it_reads_the_tree_once_though_it_asks_the_graph_twice(
         self, subject, live, filesystem
     ):
-        """Order and attribution are two questions; the compose files are read for both."""
+        """Order and attribution are two questions; the compose files answer both."""
         live()
         subject.rows(["paperless"])
         assert len(filesystem.reads) == len(TREE)
 
-    def test_rows_come_in_deploy_order(self, subject, live):
-        live()
-        assert [row.stack for row in subject.rows(["paperless"])] == [
-            "reverse-proxy",
-            "authentik",
-            "paperless",
-        ]
-
-
-class TestDeployPlanReport:
-    """`DeployPlan.report` — the printed plan, and what it refuses to do."""
+    # --- the plan it prints --------------------------------------------------
 
     def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, capsys):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
@@ -138,7 +136,9 @@ class TestDeployPlanReport:
         subject.report(["paperless"])
         assert len({line.index("→") for line in capsys.readouterr().out.splitlines()}) == 1
 
-    def test_the_count_is_logged_so_stdout_carries_only_the_plan(self, subject, live, capsys, caplog):
+    def test_the_count_is_logged_so_stdout_carries_only_the_plan(
+        self, subject, live, capsys, caplog
+    ):
         live()
         subject.report(["paperless"])
         assert "3 stack(s) — plan only, nothing deployed." in caplog.text

--- a/tools/ci/tests/unit/test_deploy.py
+++ b/tools/ci/tests/unit/test_deploy.py
@@ -50,7 +50,7 @@ class TestDeployPlanner:
 
     # --- the plan it builds -------------------------------------------------
 
-    def test_a_target_pulls_in_its_chain_each_row_carrying_its_live_state(
+    def test_rows_a_target_pulls_in_its_chain_each_carrying_its_live_state(
         self, subject, live
     ):
         """One assertion for the whole plan: order, state, and why each row is there."""
@@ -64,7 +64,7 @@ class TestDeployPlanner:
             PlanRow("paperless", StackState.ABSENT, Origin.TARGET),
         ]
 
-    def test_a_shared_dependency_names_every_target_and_a_named_target_stays_one(
+    def test_rows_a_shared_dependency_names_every_target_that_needs_it(
         self, subject, live
     ):
         live()
@@ -79,7 +79,7 @@ class TestDeployPlanner:
             PlanRow("paperless", StackState.ABSENT, Origin.TARGET),
         ]
 
-    def test_a_full_plan_has_no_target_to_attribute_rows_to(self, subject, live):
+    def test_rows_a_full_plan_has_no_target_to_attribute_rows_to(self, subject, live):
         live()
         assert subject.rows(None) == [
             PlanRow("reverse-proxy", StackState.ABSENT, Origin.WHOLE_TREE),
@@ -87,7 +87,7 @@ class TestDeployPlanner:
             PlanRow("paperless", StackState.ABSENT, Origin.WHOLE_TREE),
         ]
 
-    def test_it_reads_the_tree_once_though_it_asks_the_graph_twice(
+    def test_rows_reads_the_tree_once_though_it_asks_the_graph_twice(
         self, subject, live, filesystem
     ):
         """Order and attribution are two questions; the compose files answer both."""
@@ -97,7 +97,7 @@ class TestDeployPlanner:
 
     # --- the plan it prints --------------------------------------------------
 
-    def test_it_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, capsys):
+    def test_report_prints_a_row_per_stack_with_verb_state_and_reason(self, subject, live, capsys):
         live(stacks="reverse-proxy\n", services="reverse-proxy_traefik\t1/1\n")
         assert subject.report(["paperless"]) == 0
         assert [" ".join(line.split()) for line in capsys.readouterr().out.splitlines()] == [
@@ -106,12 +106,12 @@ class TestDeployPlanner:
             "deploy paperless absent → explicit target",
         ]
 
-    def test_the_columns_line_up_so_the_states_can_be_scanned(self, subject, live, capsys):
+    def test_report_aligns_the_columns_so_the_states_can_be_scanned(self, subject, live, capsys):
         live()
         subject.report(["paperless"])
         assert len({line.index("→") for line in capsys.readouterr().out.splitlines()}) == 1
 
-    def test_the_count_is_logged_so_stdout_carries_only_the_plan(
+    def test_report_logs_the_count_so_stdout_carries_only_the_plan(
         self, subject, live, capsys, caplog
     ):
         live()
@@ -119,7 +119,7 @@ class TestDeployPlanner:
         assert "3 stack(s) — plan only, nothing deployed." in caplog.text
         assert "stack(s)" not in capsys.readouterr().out
 
-    def test_it_only_ever_lists(self, subject, live, commands):
+    def test_report_only_ever_lists_the_cluster(self, subject, live, commands):
         live()
         subject.report(None)
         assert [argv[:3] for argv in argvs(commands)] == [
@@ -127,7 +127,7 @@ class TestDeployPlanner:
             ["docker", "service", "ls"],
         ]
 
-    def test_an_unresolvable_graph_exits_one_before_touching_the_cluster(
+    def test_report_an_unresolvable_graph_exits_one_before_touching_the_cluster(
         self, subject, filesystem, capsys, caplog, commands
     ):
         filesystem.files["stacks/apps/ghost/docker-compose.yml"] = (
@@ -138,7 +138,7 @@ class TestDeployPlanner:
         assert "ghost requires nope" in caplog.text
         assert argvs(commands) == []
 
-    def test_an_unreachable_cluster_exits_one_and_explains(self, subject, commands, caplog):
+    def test_report_an_unreachable_cluster_exits_one_and_explains(self, subject, commands, caplog):
         responds(commands, CommandResult(1, "", "Cannot connect to the Docker daemon"))
         assert subject.report(None) == 1
         assert "Cannot connect to the Docker daemon" in caplog.text

--- a/tools/ci/tests/unit/test_gc.py
+++ b/tools/ci/tests/unit/test_gc.py
@@ -80,23 +80,23 @@ class TestRegistryGc:
             "gh", "api", "--paginate", "/user/packages/container/warden/versions"
         ]
 
-    def test_a_dry_run_deletes_nothing_and_says_so(self, subject, commands, console):
+    def test_a_dry_run_deletes_nothing_and_says_so(self, subject, commands, caplog):
         responds(commands, self._listing([_v(4, 30, ["oldsha"])]))
         assert subject.prune() == 1
         assert argvs(commands) == [
             ["gh", "api", "--paginate", "/user/packages/container/warden/versions"]
         ]
-        assert console.stdout[-1] == "Would prune 1 version(s)."
-        assert "[dry-run] would delete version 4" in console.text
+        assert caplog.messages[-1] == "Would prune 1 version(s)."
+        assert "[dry-run] would delete version 4" in caplog.text
 
-    def test_apply_issues_a_delete_per_stale_version(self, subject, commands, console):
+    def test_apply_issues_a_delete_per_stale_version(self, subject, commands, caplog):
         responds(commands, self._listing([_v(4, 30, ["oldsha"]), _v(6, 30, [])]))
         assert subject.prune(apply=True) == 2
         assert argvs(commands)[1:] == [
             ["gh", "api", "-X", "DELETE", "/user/packages/container/warden/versions/4"],
             ["gh", "api", "-X", "DELETE", "/user/packages/container/warden/versions/6"],
         ]
-        assert console.stdout[-1] == "Pruned 2 version(s)."
+        assert caplog.messages[-1] == "Pruned 2 version(s)."
 
     def test_a_release_version_is_never_deleted(self, subject, commands):
         responds(commands, self._listing([_v(1, 900, ["1.2.0"])]))

--- a/tools/ci/tests/unit/test_idempotence.py
+++ b/tools/ci/tests/unit/test_idempotence.py
@@ -96,12 +96,13 @@ class TestIdempotenceCheck:
         assert "✓ second run reported no change on 2 host(s)" in caplog.text
 
     def test_both_runs_stream_ansibles_own_output_through_untouched(
-        self, subject, commands, output
+        self, subject, commands, capsys
     ):
         responds(commands, CommandResult(0, CONVERGED, "warn\n"), CommandResult(0, CONVERGED))
         subject.verify(self.PLAYBOOK)
-        assert output.raw_stdout == [CONVERGED, CONVERGED]
-        assert output.raw_stderr == ["warn\n", ""]
+        streams = capsys.readouterr()
+        assert streams.out == CONVERGED + CONVERGED
+        assert streams.err == "warn\n"
 
     def test_the_playbook_runs_exactly_twice_with_the_same_argv(self, subject, commands):
         responds(commands, CommandResult(0, CONVERGED), CommandResult(0, CONVERGED))

--- a/tools/ci/tests/unit/test_idempotence.py
+++ b/tools/ci/tests/unit/test_idempotence.py
@@ -90,10 +90,18 @@ class TestIdempotenceCheck:
     def subject(self, container):
         return container.idempotence()
 
-    def test_a_converged_second_run_passes(self, subject, commands, console):
+    def test_a_converged_second_run_passes(self, subject, commands, caplog):
         responds(commands, CommandResult(0, CONVERGED), CommandResult(0, CONVERGED))
         assert subject.verify(self.PLAYBOOK) == 0
-        assert "✓ second run reported no change on 2 host(s)" in console.text
+        assert "✓ second run reported no change on 2 host(s)" in caplog.text
+
+    def test_both_runs_stream_ansibles_own_output_through_untouched(
+        self, subject, commands, output
+    ):
+        responds(commands, CommandResult(0, CONVERGED, "warn\n"), CommandResult(0, CONVERGED))
+        subject.verify(self.PLAYBOOK)
+        assert output.raw_stdout == [CONVERGED, CONVERGED]
+        assert output.raw_stderr == ["warn\n", ""]
 
     def test_the_playbook_runs_exactly_twice_with_the_same_argv(self, subject, commands):
         responds(commands, CommandResult(0, CONVERGED), CommandResult(0, CONVERGED))
@@ -101,18 +109,18 @@ class TestIdempotenceCheck:
         expected = ["ansible-playbook", self.PLAYBOOK, "-i", "inventory/"]
         assert argvs(commands) == [expected, expected]
 
-    def test_a_changed_second_run_fails_naming_the_host(self, subject, commands, console):
+    def test_a_changed_second_run_fails_naming_the_host(self, subject, commands, caplog):
         responds(commands, CommandResult(0, CONVERGED), CommandResult(0, DRIFTED))
         assert subject.verify(self.PLAYBOOK) == 1
-        assert "manager-01: changed=3" in console.text
+        assert "manager-01: changed=3" in caplog.text
 
-    def test_a_failed_first_run_never_reaches_the_second(self, subject, commands, console):
+    def test_a_failed_first_run_never_reaches_the_second(self, subject, commands, caplog):
         responds(commands, CommandResult(2, "boom"))
         assert subject.verify(self.PLAYBOOK) == 2
         assert len(argvs(commands)) == 1
-        assert "nothing to compare" in console.text
+        assert "nothing to compare" in caplog.text
 
-    def test_a_second_run_with_no_recap_is_a_failure_not_a_pass(self, subject, commands, console):
+    def test_a_second_run_with_no_recap_is_a_failure_not_a_pass(self, subject, commands, caplog):
         responds(commands, CommandResult(0, CONVERGED), CommandResult(0, "died early"))
         assert subject.verify(self.PLAYBOOK) == 1
-        assert "did not complete" in console.text
+        assert "did not complete" in caplog.text

--- a/tools/ci/tests/unit/test_ports.py
+++ b/tools/ci/tests/unit/test_ports.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import pytest
 
 from ci import ports
-from ci.adapters import CommandResult, LocalFileSystem, StdoutOutput, Subprocess, SystemClock
-from conftest import FakeFileSystem, FixedClock, RecordingOutput
+from ci.adapters import CommandResult, LocalFileSystem, Subprocess, SystemClock
+from conftest import FakeFileSystem, FixedClock
 
 
 @pytest.mark.parametrize(
@@ -18,7 +18,6 @@ from conftest import FakeFileSystem, FixedClock, RecordingOutput
     [
         (ports.FileSystem, LocalFileSystem(), FakeFileSystem()),
         (ports.Clock, SystemClock(), FixedClock()),
-        (ports.Output, StdoutOutput(), RecordingOutput()),
     ],
 )
 def test_the_fake_and_the_real_adapter_satisfy_the_same_port(port, real, fake):

--- a/tools/ci/tests/unit/test_ports.py
+++ b/tools/ci/tests/unit/test_ports.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import pytest
 
 from ci import ports
-from ci.adapters import CommandResult, LocalFileSystem, StdoutConsole, Subprocess, SystemClock
-from conftest import FakeFileSystem, FixedClock, RecordingConsole
+from ci.adapters import CommandResult, LocalFileSystem, StdoutOutput, Subprocess, SystemClock
+from conftest import FakeFileSystem, FixedClock, RecordingOutput
 
 
 @pytest.mark.parametrize(
@@ -18,7 +18,7 @@ from conftest import FakeFileSystem, FixedClock, RecordingConsole
     [
         (ports.FileSystem, LocalFileSystem(), FakeFileSystem()),
         (ports.Clock, SystemClock(), FixedClock()),
-        (ports.Console, StdoutConsole(), RecordingConsole()),
+        (ports.Output, StdoutOutput(), RecordingOutput()),
     ],
 )
 def test_the_fake_and_the_real_adapter_satisfy_the_same_port(port, real, fake):

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 
 import pytest
 
-from ci.stackgraph import Stack, StackTree, UnresolvedGraph, cycle_members, resolve
+from ci.stackgraph import (
+    Stack,
+    StackTree,
+    UnresolvedGraph,
+    cycle_members,
+    required_by,
+    resolve,
+)
 from conftest import ROOT, FakeFileSystem
 
 ROUTED = {
@@ -81,6 +88,34 @@ def test_resolve_treats_a_stack_requiring_itself_as_a_cycle():
     with pytest.raises(UnresolvedGraph) as exc:
         resolve({"loop": ["loop"]})
     assert str(exc.value) == "dependency cycle among: loop"
+
+
+def test_required_by_attributes_a_dependency_to_the_target_that_named_it():
+    assert required_by(ROUTED, ["paperless"])["authentik"] == ["paperless"]
+
+
+def test_required_by_attributes_a_transitive_dependency_to_the_target_not_the_middle():
+    assert required_by(ROUTED, ["paperless"])["reverse-proxy"] == ["paperless"]
+
+
+def test_required_by_names_every_target_that_reaches_a_shared_dependency():
+    assert required_by(ROUTED, ["paperless", "authentik"])["reverse-proxy"] == [
+        "authentik",
+        "paperless",
+    ]
+
+
+def test_required_by_never_makes_a_target_its_own_dependency():
+    assert "paperless" not in required_by(ROUTED, ["paperless"])
+
+
+def test_required_by_ignores_a_disabled_stack_and_the_edges_into_it():
+    graph = {"dns": [], "reverse-proxy": ["dns"], "paperless": ["reverse-proxy"]}
+    assert required_by(graph, ["paperless"], disabled=["dns"]) == {"reverse-proxy": ["paperless"]}
+
+
+def test_required_by_survives_a_cycle_rather_than_looping_forever():
+    assert required_by(CYCLE, ["komga"]) == {"authentik": ["komga"], "paperless": ["komga"]}
 
 
 def test_cycle_members_names_only_the_cycle_not_the_stacks_it_blocks():

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -203,7 +203,7 @@ class TestStackTree:
         assert sorted(filesystem.reads) == sorted(set(filesystem.reads))
         assert len(filesystem.reads) == 3
 
-    def test_asking_again_does_not_re_read_the_tree(self, subject, filesystem):
+    def test_stacks_asking_again_does_not_re_read_the_tree(self, subject, filesystem):
         """Callers ask several questions of one tree; the disk is read for the first."""
         self._seed(filesystem, paperless=DECLARED, komga=DECLARED, kopia=DECLARED)
         subject.stacks()
@@ -311,47 +311,45 @@ class TestThisRepo:
         assert subject.undeclared() == {}
 
 
-class TestCheckDependencies:
-    """`check_dependencies` — the verdict `ci check-deps` prints."""
+def _tree(filesystem: FakeFileSystem, **stacks: str) -> None:
+    filesystem.files.update(compose(**stacks))
 
-    @pytest.fixture
-    def subject(self, container):
-        return container.graph()
 
-    def _seed(self, filesystem: FakeFileSystem, **stacks: str) -> None:
-        filesystem.files.update(compose(**stacks))
+def test_check_dependencies_passes_a_tree_that_resolves_and_declares_everything(
+    container, filesystem, caplog
+):
+    _tree(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
+    assert check_dependencies(container.graph()) == 0
+    assert "✓ 2 stacks resolve" in caplog.text
 
-    def test_a_tree_that_resolves_and_declares_everything_passes(
-        self, subject, filesystem, caplog
-    ):
-        self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
-        assert check_dependencies(subject) == 0
-        assert "✓ 2 stacks resolve" in caplog.text
 
-    def test_an_undeclared_dependency_fails_naming_the_stack_and_what_it_hid(
-        self, subject, filesystem, caplog
-    ):
-        self._seed(filesystem, komga=TRAEFIK_LABEL, **{"reverse-proxy": "services: {}\n"})
-        assert check_dependencies(subject) == 1
-        assert "    komga: reverse-proxy" in caplog.text
+def test_check_dependencies_names_the_stack_hiding_an_undeclared_dependency(
+    container, filesystem, caplog
+):
+    _tree(filesystem, komga=TRAEFIK_LABEL, **{"reverse-proxy": "services: {}\n"})
+    assert check_dependencies(container.graph()) == 1
+    assert "    komga: reverse-proxy" in caplog.text
 
-    def test_an_unresolvable_graph_fails_before_it_looks_for_undeclared_edges(
-        self, subject, filesystem, caplog
-    ):
-        self._seed(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
-        assert check_dependencies(subject) == 1
-        assert "gamarr requires romm" in caplog.text
 
-    def test_it_reads_the_tree_once_however_many_questions_it_asks(
-        self, subject, filesystem
-    ):
-        self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
-        check_dependencies(subject)
-        assert len(filesystem.reads) == 2
+def test_check_dependencies_fails_on_an_unresolvable_graph_before_looking_for_gaps(
+    container, filesystem, caplog
+):
+    _tree(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
+    assert check_dependencies(container.graph()) == 1
+    assert "gamarr requires romm" in caplog.text
 
-    def test_a_malformed_declaration_fails_explaining_the_shape(
-        self, subject, filesystem, caplog
-    ):
-        self._seed(filesystem, paperless="x-homelab:\n    requires: reverse-proxy\nservices: {}\n")
-        assert check_dependencies(subject) == 1
-        assert "x-homelab.requires must be a list" in caplog.text
+
+def test_check_dependencies_explains_the_shape_of_a_malformed_declaration(
+    container, filesystem, caplog
+):
+    _tree(filesystem, paperless="x-homelab:\n    requires: reverse-proxy\nservices: {}\n")
+    assert check_dependencies(container.graph()) == 1
+    assert "x-homelab.requires must be a list" in caplog.text
+
+
+def test_check_dependencies_reads_the_tree_once_however_many_questions_it_asks(
+    container, filesystem
+):
+    _tree(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
+    check_dependencies(container.graph())
+    assert len(filesystem.reads) == 2

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -9,8 +9,10 @@ everything that would read the tree goes through a fake filesystem.
 from __future__ import annotations
 
 import pytest
+from dependency_injector import providers
 
 from ci.stackgraph import (
+    DependencyCheck,
     Stack,
     StackTree,
     UnresolvedGraph,
@@ -258,14 +260,14 @@ class TestDependencyGraph:
     ):
         self._seed(filesystem, dns="services: {}\n",
                    paperless="x-homelab:\n    requires: [dns]\nservices: {}\n")
-        container.config.env.from_value({"PRIMARY_DNS_MANAGED": value})
+        container.env.override(providers.Object({"PRIMARY_DNS_MANAGED": value}))
         subject = container.graph()
         assert subject.disabled() == {"dns"}
         assert subject.resolve() == ["paperless"]
 
     def test_a_truthy_gate_keeps_its_provider(self, container, filesystem):
         self._seed(filesystem, dns="services: {}\n")
-        container.config.env.from_value({"PRIMARY_DNS_MANAGED": "true"})
+        container.env.override(providers.Object({"PRIMARY_DNS_MANAGED": "true"}))
         assert container.graph().disabled() == set()
 
 
@@ -288,3 +290,42 @@ class TestThisRepo:
 
     def test_every_dependency_the_tree_reveals_is_declared(self, subject):
         assert subject.undeclared() == {}
+
+
+class TestDependencyCheck:
+    """`DependencyCheck` — the pre-commit hook's verdict on the declarations."""
+
+    @pytest.fixture
+    def subject(self, container):
+        return container.dependency_check()
+
+    def _seed(self, filesystem: FakeFileSystem, **stacks: str) -> None:
+        filesystem.files.update(compose(**stacks))
+
+    def test_a_tree_that_resolves_and_declares_everything_passes(
+        self, subject, filesystem, console
+    ):
+        self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
+        assert subject.report() == 0
+        assert console.text.startswith("✓ 2 stacks resolve")
+
+    def test_an_undeclared_dependency_fails_naming_the_stack_and_what_it_hid(
+        self, subject, filesystem, console
+    ):
+        self._seed(filesystem, komga=TRAEFIK_LABEL, **{"reverse-proxy": "services: {}\n"})
+        assert subject.report() == 1
+        assert "    komga: reverse-proxy" in console.text
+
+    def test_an_unresolvable_graph_fails_before_it_looks_for_undeclared_edges(
+        self, subject, filesystem, console
+    ):
+        self._seed(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
+        assert subject.report() == 1
+        assert "gamarr requires romm" in console.text
+
+    def test_a_malformed_declaration_fails_explaining_the_shape(
+        self, subject, filesystem, console
+    ):
+        self._seed(filesystem, paperless="x-homelab:\n    requires: reverse-proxy\nservices: {}\n")
+        assert subject.report() == 1
+        assert "x-homelab.requires must be a list" in console.text

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -12,10 +12,10 @@ import pytest
 from dependency_injector import providers
 
 from ci.stackgraph import (
-    DependencyCheck,
     Stack,
     StackTree,
     UnresolvedGraph,
+    check_dependencies,
     cycle_members,
     required_by,
     resolve,
@@ -114,6 +114,17 @@ def test_required_by_never_makes_a_target_its_own_dependency():
 def test_required_by_ignores_a_disabled_stack_and_the_edges_into_it():
     graph = {"dns": [], "reverse-proxy": ["dns"], "paperless": ["reverse-proxy"]}
     assert required_by(graph, ["paperless"], disabled=["dns"]) == {"reverse-proxy": ["paperless"]}
+
+
+def test_required_by_rejects_a_dangling_edge_exactly_as_resolve_does():
+    """Both walk the same declarations, so both must refuse the same broken ones."""
+    with pytest.raises(UnresolvedGraph, match="paperless requires ghost-stack"):
+        required_by({"paperless": ["ghost-stack"]}, ["paperless"])
+
+
+def test_required_by_rejects_a_target_that_does_not_exist():
+    with pytest.raises(UnresolvedGraph, match="no such stack: ghost-stack"):
+        required_by(ROUTED, ["ghost-stack"])
 
 
 def test_required_by_survives_a_cycle_rather_than_looping_forever():
@@ -300,12 +311,12 @@ class TestThisRepo:
         assert subject.undeclared() == {}
 
 
-class TestDependencyCheck:
-    """`DependencyCheck` — the pre-commit hook's verdict on the declarations."""
+class TestCheckDependencies:
+    """`check_dependencies` — the verdict `ci check-deps` prints."""
 
     @pytest.fixture
     def subject(self, container):
-        return container.dependency_check()
+        return container.graph()
 
     def _seed(self, filesystem: FakeFileSystem, **stacks: str) -> None:
         filesystem.files.update(compose(**stacks))
@@ -314,33 +325,33 @@ class TestDependencyCheck:
         self, subject, filesystem, caplog
     ):
         self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
-        assert subject.report() == 0
+        assert check_dependencies(subject) == 0
         assert "✓ 2 stacks resolve" in caplog.text
 
     def test_an_undeclared_dependency_fails_naming_the_stack_and_what_it_hid(
         self, subject, filesystem, caplog
     ):
         self._seed(filesystem, komga=TRAEFIK_LABEL, **{"reverse-proxy": "services: {}\n"})
-        assert subject.report() == 1
+        assert check_dependencies(subject) == 1
         assert "    komga: reverse-proxy" in caplog.text
 
     def test_an_unresolvable_graph_fails_before_it_looks_for_undeclared_edges(
         self, subject, filesystem, caplog
     ):
         self._seed(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
-        assert subject.report() == 1
+        assert check_dependencies(subject) == 1
         assert "gamarr requires romm" in caplog.text
 
     def test_it_reads_the_tree_once_however_many_questions_it_asks(
         self, subject, filesystem
     ):
         self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
-        subject.report()
+        check_dependencies(subject)
         assert len(filesystem.reads) == 2
 
     def test_a_malformed_declaration_fails_explaining_the_shape(
         self, subject, filesystem, caplog
     ):
         self._seed(filesystem, paperless="x-homelab:\n    requires: reverse-proxy\nservices: {}\n")
-        assert subject.report() == 1
+        assert check_dependencies(subject) == 1
         assert "x-homelab.requires must be a list" in caplog.text

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -192,6 +192,14 @@ class TestStackTree:
         assert sorted(filesystem.reads) == sorted(set(filesystem.reads))
         assert len(filesystem.reads) == 3
 
+    def test_asking_again_does_not_re_read_the_tree(self, subject, filesystem):
+        """Callers ask several questions of one tree; the disk is read for the first."""
+        self._seed(filesystem, paperless=DECLARED, komga=DECLARED, kopia=DECLARED)
+        subject.stacks()
+        subject.stacks()
+        subject.stacks()
+        assert len(filesystem.reads) == 3
+
     def test_a_name_used_in_both_roots_fails_rather_than_shadowing(self, subject, filesystem):
         filesystem.files.update(
             {
@@ -322,6 +330,13 @@ class TestDependencyCheck:
         self._seed(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
         assert subject.report() == 1
         assert "gamarr requires romm" in caplog.text
+
+    def test_it_reads_the_tree_once_however_many_questions_it_asks(
+        self, subject, filesystem
+    ):
+        self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
+        subject.report()
+        assert len(filesystem.reads) == 2
 
     def test_a_malformed_declaration_fails_explaining_the_shape(
         self, subject, filesystem, caplog

--- a/tools/ci/tests/unit/test_stackgraph.py
+++ b/tools/ci/tests/unit/test_stackgraph.py
@@ -303,29 +303,29 @@ class TestDependencyCheck:
         filesystem.files.update(compose(**stacks))
 
     def test_a_tree_that_resolves_and_declares_everything_passes(
-        self, subject, filesystem, console
+        self, subject, filesystem, caplog
     ):
         self._seed(filesystem, paperless=DECLARED, **{"reverse-proxy": "services: {}\n"})
         assert subject.report() == 0
-        assert console.text.startswith("✓ 2 stacks resolve")
+        assert "✓ 2 stacks resolve" in caplog.text
 
     def test_an_undeclared_dependency_fails_naming_the_stack_and_what_it_hid(
-        self, subject, filesystem, console
+        self, subject, filesystem, caplog
     ):
         self._seed(filesystem, komga=TRAEFIK_LABEL, **{"reverse-proxy": "services: {}\n"})
         assert subject.report() == 1
-        assert "    komga: reverse-proxy" in console.text
+        assert "    komga: reverse-proxy" in caplog.text
 
     def test_an_unresolvable_graph_fails_before_it_looks_for_undeclared_edges(
-        self, subject, filesystem, console
+        self, subject, filesystem, caplog
     ):
         self._seed(filesystem, gamarr="x-homelab:\n    requires: [romm]\nservices: {}\n")
         assert subject.report() == 1
-        assert "gamarr requires romm" in console.text
+        assert "gamarr requires romm" in caplog.text
 
     def test_a_malformed_declaration_fails_explaining_the_shape(
-        self, subject, filesystem, console
+        self, subject, filesystem, caplog
     ):
         self._seed(filesystem, paperless="x-homelab:\n    requires: reverse-proxy\nservices: {}\n")
         assert subject.report() == 1
-        assert "x-homelab.requires must be a list" in console.text
+        assert "x-homelab.requires must be a list" in caplog.text


### PR DESCRIPTION
Closes #111 — phase 1.2 of the restructure plan.

`ci deploy --plan` listed every stack in the tree. It now reports what the cluster
already holds, so the plan shows what a deploy would *change* rather than everything
it could touch.

```
$ uv run ci deploy paperless --plan
  ensure   reverse-proxy   converged   → required by paperless
  ensure   authentik       converged   → required by paperless
  deploy   paperless       converged   → explicit target
```

States are `absent` (not in `docker stack ls`), `present` (listed, some service short
of its desired replicas) and `converged` (every service at desired). There is no
readiness state: Swarm promotes a task to `running` only once its healthcheck passes,
so convergence *is* health.

### What is here

- `ci/cluster.py` — `SwarmCluster` reads `docker stack ls` and `docker service ls`
  once per invocation and caches the result. Both are list commands; nothing writes.
- `ci/deploy.py` — `DeployPlan` joins the resolved order with that live state and
  renders the aligned rows.
- `stackgraph.required_by` — for each stack a target pulls in, the named targets that
  reach it, transitively and pruned of disabled providers.

`docker service ls` exposes no namespace label, so a service is attributed to the
**longest** stack name that prefixes it, resolved against the set `docker stack ls`
reports — that is what separates `actual_server_actual_mcp` (stack `actual_server`)
from a hypothetical stack `actual`. There are no prefix collisions among the current
54 names, and `actual_server` resolves correctly against the live cluster.

### Two scope decisions

- **No `skip` column.** The issue's example shows `converged … skip` on the
  reverse-proxy row. Whether a converged dependency is skipped is 1.3's decision
  ("dependencies are *ensured*, not redeployed"); 1.2 reports state and attribution
  only. The `ensure`/`deploy` verb already separates dependency from named target.
- **A full plan leaves the reason column blank.** With no targets there is nothing to
  attribute rows to, so it prints `deploy <stack> <state>` rather than inventing a
  third reason string.

### Standing rules

**The check lands before the fix.** Red-first: `test_cluster.py` (12 cases),
`test_deploy.py` (16) and 6 `required_by` cases in `test_stackgraph.py` were written
and confirmed failing before `ci/cluster.py`, `ci/deploy.py` or `required_by` existed.
Suite: **180 → 216 passing**. The plan lists 1.2 as `lands —`, so no new ratcheted
check; the count stays at 15.

**Behaviour-preserving means spec-diff clean.** This story is read-only, so the
stronger claim holds — all **112 service specs byte-identical** before and after,
not merely `Mounts`-order-different:

```
docker service inspect <112 services> --format '{{.Spec.Name}} {{json .Spec}}' | sort
  → captured before, re-captured after running the plan 3×
SPEC DIFF CLEAN: all 112 service specs byte-identical before and after
same 54 stacks
```

Enforced in the suite too: `test_it_only_ever_lists_the_cluster_never_changes_it`
asserts the exact argv list is `[docker stack ls, docker service ls]` and nothing else.

**Everything runs twice.** `ci deploy paperless --plan` run back-to-back produced
identical stdout. Reading N stacks is still two `ls` calls.

### Verified against the live cluster

- 54/54 stacks resolve to `converged`, cross-checked against `docker service ls` —
  no service is off its desired replica count, so the verdict is truthful rather than
  a stuck constant.
- `SwarmCluster.state("no-such-stack")` returns `ABSENT` against the real daemon.
- Full `pre-commit run --all-files`: 20 hooks, all pass.
